### PR TITLE
Fix lastIndexOf errors

### DIFF
--- a/NiL.JS/BaseLibrary/String.cs
+++ b/NiL.JS/BaseLibrary/String.cs
@@ -221,8 +221,9 @@ namespace NiL.JS.BaseLibrary
                 break;
             }
             var strValue = self.ToString();
-            pos += strValue.Length;
-            return strValue.LastIndexOf(fstr, System.Math.Max(0, System.Math.Min(pos, strValue.Length)), StringComparison.CurrentCulture);
+            return strValue.LastIndexOf(fstr, StringComparison.CurrentCulture) == 0
+                    ? 0
+                    : strValue.LastIndexOf(fstr, System.Math.Max(0, System.Math.Min(pos, strValue.Length - 1)), StringComparison.CurrentCulture);
         }
 
         [DoNotEnumerate]


### PR DESCRIPTION
Hi!

Function lastIndexOf has the following errors:
```javascript
'qwerty'.lastIndexOf('e', 1); // returns 2, must be -1
'qwerty'.lastIndexOf('e', 0); // returns 2, must be -1
'qwerty'.lastIndexOf('e', -3); // returns 2, must be -1
'qwerty'.lastIndexOf('qwe', -1000); // returns -1, must be 0
```
It also fixes some failed tests with Mono:

> ...
> TypeError: Array index is out of range.
> File: "tests\sputnik\ch15\15.5\15.5.4\15.5.4.10\S15.5.4.10_A2_T10.js"
> 
> TypeError: Array index is out of range.
> File: "tests\sputnik\ch15\15.5\15.5.4\15.5.4.10\S15.5.4.10_A2_T11.js"
> ...