### PR TITLE
Some small fixes

### DIFF
--- a/NiL.JS/BaseLibrary/String.cs
+++ b/NiL.JS/BaseLibrary/String.cs
@@ -525,7 +525,8 @@ namespace NiL.JS.BaseLibrary
                 if ((args[0].oValue as RegExp).regEx.ToString().Length == 0)
                 {
                     match = match.NextMatch();
-                    limit = (uint)selfString.Length;
+                    if (limit == uint.MaxValue)
+                        limit = (uint)selfString.Length;
                 }
                 Array res = new Array();
                 int index = 0;

--- a/NiL.JS/Core/JSObject.cs
+++ b/NiL.JS/Core/JSObject.cs
@@ -843,8 +843,6 @@ namespace NiL.JS.Core
                         if (self.oValue is TypeProxy)
                         {
                             var ht = (self.oValue as TypeProxy).hostedType;
-                            if (ht == typeof(RegExp))
-                                return "[object Object]";
                             return "[object " + (ht == typeof(JSObject) ? typeof(System.Object) : ht).Name + "]";
                         }
                         if (self.oValue != null)

--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -1045,32 +1045,32 @@ namespace NiL.JS.Core
                             }
                         case 't':
                             {
-                                res.Append('\t');
+                                res.Append(processRegexComp ? "\\t" : "\t");
                                 break;
                             }
                         case 'f':
                             {
-                                res.Append('\f');
+                                res.Append(processRegexComp ? "\\f" : "\f");
                                 break;
                             }
                         case 'v':
                             {
-                                res.Append('\v');
+                                res.Append(processRegexComp ? "\\v" : "\v");
                                 break;
                             }
                         case 'b':
                             {
-                                res.Append('\b');
+                                res.Append(processRegexComp ? "\\b" : "\b");
                                 break;
                             }
                         case 'n':
                             {
-                                res.Append('\n');
+                                res.Append(processRegexComp ? "\\n" : "\n");
                                 break;
                             }
                         case 'r':
                             {
-                                res.Append('\r');
+                                res.Append(processRegexComp ? "\\r" : "\r");
                                 break;
                             }
                         case 'c':
@@ -1078,13 +1078,24 @@ namespace NiL.JS.Core
                             {
                                 if (!processRegexComp)
                                     goto default;
-                                if (i + 1 >= code.Length
-                                    || ((code[i + 1] < 'a' || code[i + 1] > 'z') && (code[i + 1] < 'A' || code[i + 1] > 'Z')))
-                                    goto case 'p';
-                                i++;
-                                res.Append((char)(code[i] % 32));
-                                break;
+
+                                if (i + 1 < code.Length) {
+                                    char ch = code[i + 1];
+                                    // convert a -> A
+                                    if (ch >= 'a' && ch <= 'z')
+                                        ch = (char)(ch - ('a' - 'A'));
+                                    if ((char)(ch - '@') < ' ') {
+                                        res.Append("\\c");
+                                        res.Append(ch);
+                                        ++i;
+                                        break;
+                                    }
+                                }
+
+                                // invalid control character
+                                goto case 'p';
                             }
+                        // not supported in standard
                         case 'P':
                         case 'p':
                         case 'k':
@@ -1092,7 +1103,9 @@ namespace NiL.JS.Core
                             {
                                 if (!processRegexComp)
                                     goto default;
-                                res.Append(code[i]);
+
+                                // regex that does not match anything
+                                res.Append(@"\b\B");
                                 break;
                             }
                         default:


### PR DESCRIPTION
Commit 00f8f14 fixes problem with non-working regular expressions that contain special characters like '\n', '\r', '\b'. It fix test errors like this:

> TypeError: Can't get property "length" of "null"
> File: "tests\sputnik\ch15\15.10\15.10.2\15.10.2.6\S15.10.2.6_A3_T1.js"

Commit 862ac5a fixes incorrect processing of String.split's _limit_ parameter. Tests 15.5 are entirely passed now.

Commit 00f8f14 just fixes test 15.10.6.js.