### PR TITLE
Add support for enum types in interop method signatures

### DIFF
--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -598,7 +598,17 @@ namespace NiL.JS.Core
                                 return null;
                             }
                             if (targetType.IsEnum)
-                                return Enum.Parse(targetType, jsobj.Value.ToString());
+                            {
+                                try
+                                {
+                                    return Enum.Parse(targetType, jsobj.Value.ToString());
+                                }
+                                catch (Exception)
+                                {
+                                    // If anything went wrong while trying to parse string value, return 0 as the default Enum type value.
+                                    return 0;
+                                }
+                            }
                         }
 
                         if (targetType == typeof(string))

--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -519,6 +519,9 @@ namespace NiL.JS.Core
                         if (targetType == typeof(Number))
                             return new Number(jsobj.dValue);
 
+                        if (targetType.IsEnum)
+                            return Enum.ToObject(targetType, jsobj.dValue);
+
                         return null;
                     }
                 case JSValueType.Integer:
@@ -547,6 +550,9 @@ namespace NiL.JS.Core
 
                         if (targetType == typeof(Number))
                             return new Number(jsobj.iValue);
+
+                        if (targetType.IsEnum)
+                            return Enum.ToObject(targetType, jsobj.iValue);
 
                         return null;
                     }
@@ -591,6 +597,8 @@ namespace NiL.JS.Core
                                     return (decimal)r;
                                 return null;
                             }
+                            if (targetType.IsEnum)
+                                return Enum.Parse(targetType, jsobj.Value.ToString());
                         }
 
                         if (targetType == typeof(string))


### PR DESCRIPTION
NiL.JS currently fails to properly convert JS values into .NET counterparts when method signature includes enum types. For example code below will print Bar/Foo before the fix, and as expected Bar/Bar after.

Also includes support for automatically converting strings into appropriate enum values. I didn't add explicit exception handling for Enum.Parse, not totally sure what the author prefers to do in case like these. Let me know and I'll adjust the code if necessary.

Lastly, I didn't find interop unit tests, or did I miss them somewhere?

```
class Program
{
    static void Main(string[] args)
    {
        var context = new Context();

        context.DefineVariable("A").Assign(JSValue.Wrap(new A()));

        context.Eval("A.F(A.Bar);");
    }
}

public enum E
{
    Foo = 0,
    Bar = 1
}

public class A
{
    public E Foo
    {
        get
        {
            Console.WriteLine("Foo");
            return E.Foo;
        }
    }

    public E Bar
    {
        get
        {
            Console.WriteLine("Bar");
            return E.Bar;
        }
    }

    public void F(E v)
    {
        Console.WriteLine(v);
    }
}
```
