### PR TITLE
Fixed double to string and other small fixes

### DIFF
--- a/NiL.JS/BaseLibrary/Function.cs
+++ b/NiL.JS/BaseLibrary/Function.cs
@@ -484,7 +484,7 @@ namespace NiL.JS.BaseLibrary
                 {
 #if DEBUG && !(PORTABLE || NETCORE)
                     if (_functionDefinition.trace)
-                        Console.WriteLine("DEBUG: Exit \"" + _functionDefinition.Reference.Name + "\"");
+                        System.Console.WriteLine("DEBUG: Exit \"" + _functionDefinition.Reference.Name + "\"");
 #endif
                     _functionDefinition.recursionDepth--;
                     if (_functionDefinition.parametersStored > _functionDefinition.recursionDepth)

--- a/NiL.JS/Core/JSValue.cs
+++ b/NiL.JS/Core/JSValue.cs
@@ -544,7 +544,7 @@ namespace NiL.JS.Core
                         break;
                     }
             }
-            ExceptionHelper.Throw(new InvalidOperationException("Method GetProperty(...) of custom types must be overriden"));
+            ExceptionHelper.Throw(new InvalidOperationException("Method GetProperty(...) of custom types must be overridden"));
             return null;
         }
 

--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -820,15 +820,15 @@ namespace NiL.JS.Core
                     if (d == (d % 0.000001))
                         return res = d.ToString("0.####e-0", CultureInfo.InvariantCulture);
                 }
-                else if (abs >= 1e+21)
+                else if (abs >= 1e+19)
                     return res = d.ToString("0.####e+0", CultureInfo.InvariantCulture);
 
                 int neg = (d < 0 || (d == -0.0 && double.IsNegativeInfinity(1.0 / d))) ? 1 : 0;
 
-                if (d == 100000000000000000000d)
-                    res = "100000000000000000000";
-                else if (d == -100000000000000000000d)
-                    res = "-100000000000000000000";
+                if (d == 1000000000000000000d)
+                    res = "1000000000000000000";
+                else if (d == -1000000000000000000d)
+                    res = "-1000000000000000000";
                 else
                     res = abs < 1.0 ?
                         (neg == 1 ? "-0" : "0") :

--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -825,19 +825,22 @@ namespace NiL.JS.Core
 
                 int neg = (d < 0 || (d == -0.0 && double.IsNegativeInfinity(1.0 / d))) ? 1 : 0;
 
-                if (d == 1000000000000000000d)
-                    res = "1000000000000000000";
-                else if (d == -1000000000000000000d)
-                    res = "-1000000000000000000";
-                else
-                    res = abs < 1.0 ?
-                        (neg == 1 ? "-0" : "0") :
-                        ((d < 0 ? "-" : "") + ((ulong)(System.Math.Abs(d))).ToString(CultureInfo.InvariantCulture));
-
+                ulong absIntPart = (abs < 1.0) ? 0 : (ulong)(abs);
+                res = (absIntPart == 0 ? "0" : absIntPart.ToString(CultureInfo.InvariantCulture));
+                
                 abs %= 1.0;
                 if (abs != 0 && res.Length < (15 + neg))
-                    res += abs.ToString(divFormats[15 - res.Length + neg], CultureInfo.InvariantCulture);
+                {
+                    string fracPart = abs.ToString(divFormats[15 - res.Length], CultureInfo.InvariantCulture);
+                    if (fracPart == "1")
+                        res = (absIntPart + 1).ToString(CultureInfo.InvariantCulture);
+                    else
+                        res += fracPart;
+                }
 
+                if (neg == 1)
+                    res = "-" + res;
+                
                 cachedDoubleString[cachedDoubleStringsIndex].key = d;
                 cachedDoubleString[cachedDoubleStringsIndex].value = res;
                 cachedDoubleStringsIndex = (cachedDoubleStringsIndex + 1) % 7;


### PR DESCRIPTION
I fixed the DoubleToString method.
It incorrectly converted number between 2^64 and 1e21 to "0" and it did not account for the fractional part being rounded to 1 which led to number like 2.9999... to be converted to 21 instead of 3.

It will now correctly account for a rounded fractional part and switch sooner to the exponential form, now at 1e19 instead of 1e21.

The other two thing are small mistakes I noticed: One typo and a missing System before Console.