### PR TITLE
Improved DoubleToString

### DIFF
--- a/NiL.JS/BaseLibrary/Array.cs
+++ b/NiL.JS/BaseLibrary/Array.cs
@@ -1111,7 +1111,7 @@ namespace NiL.JS.BaseLibrary
             else
             {
                 var length = Tools._GetLengthOfArraylike(self, false);
-                for (var i = 0; i < length >> 1; i++)
+                for (var i = 0; i < (length >> 1); i++)
                 {
                     JSValue i0 = i.ToString();
                     JSValue i1 = (length - 1 - i).ToString();

--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -815,46 +815,41 @@ namespace NiL.JS.Core
                 }
 
                 var abs = System.Math.Abs(d);
-                if (abs < 1.0)
-                {
-                    if (d == (d % 0.000001))
-                        return res = d.ToString("0.####e-0", CultureInfo.InvariantCulture);
-                }
+                if (abs < 0.000001)
+                    res = d.ToString("0.####e-0", CultureInfo.InvariantCulture);
                 else if (abs >= 1e+21)
-                    return res = d.ToString("0.####e+0", CultureInfo.InvariantCulture);
-                else if (d == 100000000000000000000d)
-                    return "100000000000000000000";
-                else if (d == -100000000000000000000d)
-                    return "-100000000000000000000";
-
-                int neg = (d < 0 || (d == -0.0 && double.IsNegativeInfinity(1.0 / d))) ? 1 : 0;
-
-                if (d >= 1e+18)
-                {
-                    res = ((ulong)(abs / 1000)).ToString(CultureInfo.InvariantCulture) + "000";
-                }
+                    res = d.ToString("0.####e+0", CultureInfo.InvariantCulture);
                 else
                 {
-                    ulong absIntPart = (abs < 1.0) ? 0 : (ulong)(abs);
-                    res = (absIntPart == 0 ? "0" : absIntPart.ToString(CultureInfo.InvariantCulture));
-
-                    abs %= 1.0;
-                    if (abs != 0 && res.Length < (15 + neg))
+                    int neg = (d < 0 || (d == -0.0 && double.IsNegativeInfinity(1.0 / d))) ? 1 : 0;
+    
+                    if (d >= 1e+18)
                     {
-                        string fracPart = abs.ToString(divFormats[15 - res.Length], CultureInfo.InvariantCulture);
-                        if (fracPart == "1")
-                            res = (absIntPart + 1).ToString(CultureInfo.InvariantCulture);
-                        else
-                            res += fracPart;
+                        res = ((ulong)(abs / 1000)).ToString(CultureInfo.InvariantCulture) + "000";
                     }
+                    else
+                    {
+                        ulong absIntPart = (abs < 1.0) ? 0 : (ulong)(abs);
+                        res = (absIntPart == 0 ? "0" : absIntPart.ToString(CultureInfo.InvariantCulture));
+    
+                        abs %= 1.0;
+                        if (abs != 0 && res.Length <= 15)
+                        {
+                            string fracPart = abs.ToString(divFormats[15 - res.Length], CultureInfo.InvariantCulture);
+                            if (fracPart == "1")
+                                res = (absIntPart + 1).ToString(CultureInfo.InvariantCulture);
+                            else
+                                res += fracPart;
+                        }
+                    }
+                    
+                    if (neg == 1)
+                        res = "-" + res;
                 }
-
-                if (neg == 1)
-                    res = "-" + res;
 
                 cachedDoubleString[cachedDoubleStringsIndex].key = d;
                 cachedDoubleString[cachedDoubleStringsIndex].value = res;
-                cachedDoubleStringsIndex = (cachedDoubleStringsIndex + 1) % 7;
+                cachedDoubleStringsIndex = (cachedDoubleStringsIndex + 1) & 7;
             }
 
             return res;


### PR DESCRIPTION
Changes:
1. I simplified the first `if` statement (it still does the same thing).
2. I removed the `if (d == +-100000000000000000000d)`. It was kind of useless and doesn't really help performance wise.
3. Instead of using `return` when dealing with very small or large numbers, we now set `res` to the value. This enables the results to be cached, which can improve performance.
4. What follows is hard to see thanks to GitHub, but I simply took the code between the declaration of `int neg` and the last `if (neg == 1)` and put it into the new `else` block after line 821. This has to be done because of change 3.
5. I changed `if (abs != 0 && res.Length < (15 + neg))` to `if (abs != 0 && res.Length <= 15)` because we don't have to account for the sign yet. The `<=` enables that large number can have one additional digit instead of skipping it. (e.g. now 314159265358979.3 instead of 314159265358979)
6. Changed `% 7` to `& 7` to reach the last item of the array.

I also added some parentheses.