### PR TITLE
Improved console

### DIFF
--- a/IntegrationTests/Core/ToolsTests.cs
+++ b/IntegrationTests/Core/ToolsTests.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NiL.JS.BaseLibrary;
 using NiL.JS.Core;
+using System.Collections;
+using System;
 
 namespace IntegrationTests.Core
 {
@@ -101,6 +103,8 @@ namespace IntegrationTests.Core
                 new object[] { "%.% %.2% %.-1i %e %. %.8e2f %.5 1 2 3", "%.% %.2% %.-1i %e %. %.8e2f %.5", 1, 2, 3 }
             };
 
+            var FormatArgs = (Func<IEnumerable, string>)typeof(Tools).GetMethod("FormatArgs", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic).CreateDelegate(typeof(Func<IEnumerable, string>));
+
             foreach (var val in vals)
             {
                 var args = new Arguments();
@@ -108,7 +112,7 @@ namespace IntegrationTests.Core
                 {
                     args.Add(val[i]);
                 }
-                var result = Tools.FormatArgs(args);
+                var result = FormatArgs(args);
 
                 Assert.IsTrue((result == null) == (val[0] == null));
 

--- a/IntegrationTests/Core/ToolsTests.cs
+++ b/IntegrationTests/Core/ToolsTests.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NiL.JS.BaseLibrary;
 using NiL.JS.Core;
 
 namespace IntegrationTests.Core
@@ -39,6 +40,80 @@ namespace IntegrationTests.Core
 
                 Assert.IsTrue(result);
                 Assert.AreEqual(number.Key, parsedNumber);
+            }
+        }
+
+        [TestMethod]
+        public void FormatArgsTest()
+        {
+            Context c = new Context();
+
+            var vals = new object[][]
+            {
+                // basic
+                new object[] { null }, // no arguments
+                new object[] { "", "" },
+                new object[] { "1 2", "1", 2 },
+
+                new object[] { "%s", "%s" },
+
+                // numbers
+                new object[] { "% 1 2 % 3", "%% %i %f %%", 1.1232, 2, 3 },
+                new object[] { "0 1 02 003 0004 00005 000006", "%i %.1i %.2i %.3i %.4i %.5i %.6i", 0, 1, 2, 3.1415, 4, 5.8, 6 },
+                new object[] { "0 0 0", "%i %i %i", "Infinity", "-Infinity", "NaN" },
+
+                new object[] { "0 4 0", "%i %i %i", "abc", 4.234, Number.POSITIVE_INFINITY },
+                new object[] { "0 4 0", "%i %i %i", "abc", "4.234", "Infinity" },
+                new object[] { "NaN 4.234 Infinity", "%f %f %f", "abc", 4.234, Number.POSITIVE_INFINITY },
+                new object[] { "NaN 4.234 Infinity", "%f %f %f", "abc", "4.234", "Infinity" },
+
+                // %s and %o
+                new object[] { "a b 5 4.567 NaN", "%s %s %s", "a", 'b', 5, 4.567, Number.NaN },
+
+                new object[] { "2 \"a\" \"c\" NaN", "%o %o %o %o", 2, "a", 'c', Number.NaN },
+
+                // Arrays and Objects
+                new object[] { "Array (4) [ 1, \"abc\", /abc/i, Array[2] ]", c.Eval("o=[1,'abc',/abc/i,[1,2]]") },
+                new object[] { "Object { a: 2, b: \"abc\", c: /abc/i, d: Array[2] }", c.Eval("o={a:2, b:'abc', c:/abc/i, d:[1,2]}") },
+
+                new object[] { "[object Object] [object Object]", "%s %s", new object(), JSObject.CreateObject() },
+                new object[] { "Object {  } Object {  }", "%o %o", new object(), JSObject.CreateObject() },
+
+                new object[] { "1,2,3,[object Math],function Object() { [native code] }", "%s", c.Eval("[1,2,[3],Math,Object]") },
+                new object[] { "Array (5) [ 1, 2, Array[1], Math, Object() ]", "%o", c.Eval("[1,2,[3],Math,Object]") },
+
+                new object[] { "[object Object]", "%s", c.Eval("o={a:2, b:'abc', c:Math, d:Object, e:[1,2]}") },
+                new object[] { "Object { a: 2, b: \"abc\", c: Math, d: Object(), e: Array[2], f: /abc/i }", "%o", c.Eval("o={a:2, b:'abc', c:Math, d:Object, e:[1,2], f:new RegExp('abc', 'i')}") },
+
+                // null and undefined
+                new object[] { "null undefined", "%o", JSValue.Null, JSValue.Undefined },
+                new object[] { "Object { n: null }", "%o", c.Eval("o={n:null}") },
+
+                // Math...
+                new object[] { "Math {  }", "%o", c.Eval("o=Math") },
+
+                // %o vs %O
+                new object[] { "Object { a: Object }", "%o", c.Eval("o={a:{a:{a:1}}}") },
+                new object[] { "Object { a: Object { a: Object } }", "%O", c.Eval("o={a:{a:{a:1}}}") },
+
+
+                // invalid format specifiers
+                new object[] { "%.% %.2% %.-1i %e %. %.8e2f %.5 1 2 3", "%.% %.2% %.-1i %e %. %.8e2f %.5", 1, 2, 3 }
+            };
+
+            foreach (var val in vals)
+            {
+                var args = new Arguments();
+                for (int i = 1; i < val.Length; i++)
+                {
+                    args.Add(val[i]);
+                }
+                var result = Tools.FormatArgs(args);
+
+                Assert.IsTrue((result == null) == (val[0] == null));
+
+                if (result != null)
+                    Assert.AreEqual(val[0], result);
             }
         }
     }

--- a/IntegrationTests/Core/ToolsTests.cs
+++ b/IntegrationTests/Core/ToolsTests.cs
@@ -78,7 +78,7 @@ namespace IntegrationTests.Core
                 new object[] { "Array (4) [ 1, \"abc\", /abc/i, Array[2] ]", c.Eval("o=[1,'abc',/abc/i,[1,2]]") },
                 new object[] { "Object { a: 2, b: \"abc\", c: /abc/i, d: Array[2] }", c.Eval("o={a:2, b:'abc', c:/abc/i, d:[1,2]}") },
 
-                new object[] { "[object Object] [object Object]", "%s %s", new object(), JSObject.CreateObject() },
+                new object[] { "System.Object [object Object]", "%s %s", new object(), JSObject.CreateObject() },
                 new object[] { "Object {  } Object {  }", "%o %o", new object(), JSObject.CreateObject() },
 
                 new object[] { "1,2,3,[object Math],function Object() { [native code] }", "%s", c.Eval("[1,2,[3],Math,Object]") },

--- a/NiL.JS/BaseLibrary/Console.cs
+++ b/NiL.JS/BaseLibrary/Console.cs
@@ -1,68 +1,395 @@
-﻿using NiL.JS.Core;
-using NiL.JS.Core.Interop;
-using NiL.JS.Expressions;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using NiL.JS.Core;
+using NiL.JS.Core.Functions;
 
 #if !NETCORE
 namespace NiL.JS.BaseLibrary
 {
-    internal static class console
+	/// <summary>
+	/// A console modelled after the Console Living Standard.
+	/// https://console.spec.whatwg.org
+	/// </summary>
+	public class console
     {
-        public static JSValue log(Arguments args)
+
+        public enum LogLevel
         {
-            for (var i = 0; i < args.length; i++)
+            Log = 0,
+            Info = 1,
+            Warn = 2,
+            Error = 3
+        }
+
+        private string _indentChar = "|   ";
+        private string _indentGroupBegin = "|---# {0}";
+        private string _indentGroupBegin0 = "# {0}";
+
+        private GlobalContext _globalContext;
+        private JSObject _obj;
+
+        private TextWriter[] _textWriters;
+
+        private Dictionary<string, int> _counters = new Dictionary<string, int>();
+        private List<string> _groups = new List<string>();
+        private Dictionary<string, Stopwatch> _timers = new Dictionary<string, Stopwatch>();
+
+
+        public GlobalContext GlobalContext
+        {
+            get
             {
-                if (i > 0)
-                    System.Console.Write(' ');
-                var r = args[i].ToString();
-                System.Console.Write(r);
+                return _globalContext;
+            }
+        }
+
+        public JSObject ConsoleObject
+        {
+            get
+            {
+                return _obj;
+            }
+        }
+
+        
+        internal console(GlobalContext globalContext)
+            :this(globalContext, null, null, null, null)
+        {
+        }
+        internal console(GlobalContext globalContext, TextWriter logTw, TextWriter infoTw, TextWriter warnTw, TextWriter errorTw)
+        {
+            this._globalContext = globalContext;
+            this._textWriters = new TextWriter[4] { logTw, infoTw, warnTw, errorTw };
+            CreateConsoleObject();
+        }
+
+        internal void CreateConsoleObject()
+        {
+            _obj = JSObject.CreateObject();
+
+            _obj["assert"] = new ExternalFunction(this.assert);
+            _obj["clear"] = new ExternalFunction(this.clear);
+            _obj["count"] = new ExternalFunction(this.count);
+            _obj["debug"] = new ExternalFunction(this.debug);
+            _obj["error"] = new ExternalFunction(this.error);
+            _obj["info"] = new ExternalFunction(this.info);
+            _obj["log"] = new ExternalFunction(this.log);
+            //_obj["table"] = new ExternalFunction(this.table);
+            //_obj["trace"] = new ExternalFunction(this.trace);
+            _obj["warn"] = new ExternalFunction(this.warn);
+            _obj["dir"] = new ExternalFunction(this.dir);
+            //_obj["dirxml"] = new ExternalFunction(this.dirxml);
+            
+            _obj["group"] = new ExternalFunction(this.group);
+            _obj["groupCollapsed"] = new ExternalFunction(this.groupCollapsed);
+            _obj["groupEnd"] = new ExternalFunction(this.groupEnd);
+
+            _obj["time"] = new ExternalFunction(this.time);
+            _obj["timeEnd"] = new ExternalFunction(this.timeEnd);
+        }
+
+        
+        public TextWriter GetLogger(LogLevel ll)
+        {
+            int lli = (int)ll;
+
+            TextWriter res = null;
+            if (lli >= 0 && lli < _textWriters.Length)
+                res = _textWriters[lli];
+
+            if (res == null)
+            {
+                if (ll == LogLevel.Error)
+                    res = System.Console.Error;
+                else
+                    res = System.Console.Out;
             }
 
-            System.Console.WriteLine();
+            return res;
+        }
+        public void SetLogger(LogLevel ll, TextWriter value)
+        {
+            int lli = (int)ll;
+            if (lli >= 0 && lli < _textWriters.Length)
+                _textWriters[lli] = value;
+        }
+        
+        public void LogArguments(LogLevel level, Arguments args)
+        {
+            LogArguments(level, args, 0, args.length, true);
+        }
+        public void LogArguments(LogLevel level, Arguments args, int argsStart)
+        {
+            LogArguments(level, args, argsStart, args.length, true);
+        }
+        public void LogArguments(LogLevel level, Arguments args, int argsStart, int argsStop, bool formatted)
+        {
+            if (args.length == 0 || args.length <= argsStart)
+                return;
+
+            LogMessage(level, Tools.FormatArgs(args, argsStart, argsStop, formatted));
+        }
+        public void LogMessage(LogLevel level, string message)
+        {
+            Print(level, GetLogger(level), message, _groups.Count);
+        }
+        
+        public void Print(LogLevel level, TextWriter textWriter, string message)
+        {
+            Print(level, textWriter, message, 0);
+        }
+        public void Print(LogLevel level, TextWriter textWriter, string message, int indent)
+        {
+            if (message == null || textWriter == null)
+                return;
+
+            if (indent > 0)
+            {
+                string ind = "";
+                for (int j = 0; j < indent; j++)
+                    ind += _indentChar;
+
+                int last = 0;
+                for (int i = 0; i < message.Length; i++)
+                {
+                    if (message[i] == '\n' || message[i] == '\r')
+                    {
+                        textWriter.WriteLine(ind + message.Substring(last, i - last));
+                        if (message[i] == '\r' && i + 1 < message.Length && message[i + 1] == '\n')
+                            i++;
+                        last = i + 1;
+                    }
+                }
+                textWriter.WriteLine(ind + message.Substring(last));
+            }
+            else
+                textWriter.WriteLine(message);
+        }
+
+
+        public JSValue assert(JSValue thisBind, Arguments args)
+        {
+            if (!(bool)args[0])
+                LogArguments(LogLevel.Log, args, 1);
             return JSValue.undefined;
         }
 
-        public static JSValue assert(Arguments args)
+        public JSValue clear(JSValue thisBind, Arguments args)
         {
-            if (!(bool)args[0])
-            {
-                for (var i = 1; i < args.length; i++)
-                {
-                    if (i > 1)
-                        System.Console.Error.Write(" ");
-                    var r = args[i].ToString();
-                    System.Console.Error.Write(r);
-                }
+            _groups.Clear();
+            //System.Console.Clear();
 
-                System.Console.Error.WriteLine();
-            }
-            return null;
+            return JSValue.undefined;
+        }
+
+        public JSValue count(JSValue thisBind, Arguments args)
+        {
+            string label = "";
+            if (args.length > 0)
+                label = (args[0] ?? "null").ToString();
+
+            if (!_counters.ContainsKey(label))
+                _counters.Add(label, 0);
+
+            string c = Tools.Int32ToString(++_counters[label]);
+            
+            if (label != "")
+                label += ": ";
+            LogMessage(LogLevel.Info, label + c);
+
+            return JSValue.undefined;
+        }
+
+        public JSValue debug(JSValue thisBind, Arguments args)
+        {
+            LogArguments(LogLevel.Log, args);
+            return JSValue.undefined;
         }
         
-        public static void asserta(Function f, JSValue sample)
+        public JSValue error(JSValue thisBind, Arguments args)
         {
-            if (sample == null || !sample.Exists)
-                sample = Boolean.True;
-
-            if (!JSObject.@is(f.Call(null), sample))
-            {
-                var message = f.ToString();
-                message = message.Substring(message.IndexOf("=>") + 2).Trim();
-                System.Console.Error.WriteLine(message + " not equals " + sample);
-            }
+            LogArguments(LogLevel.Error, args);
+            return JSValue.undefined;
+        }
+        
+        public JSValue info(JSValue thisBind, Arguments args)
+        {
+            LogArguments(LogLevel.Info, args);
+            return JSValue.undefined;
+        }
+        
+        public JSValue log(JSValue thisBind, Arguments args)
+        {
+            LogArguments(LogLevel.Log, args);
+            return JSValue.undefined;
         }
 
-        public static JSValue error(Arguments args)
+        //public JSValue table(JSValue thisBind, Arguments args)
+        //{
+        //    return JSValue.undefined;
+        //}
+
+        //public JSValue trace(JSValue thisBind, Arguments args)
+        //{
+        //    return JSValue.undefined;
+        //}
+
+        public JSValue warn(JSValue thisBind, Arguments args)
         {
-            for (var i = 0; i < args.length; i++)
+            LogArguments(LogLevel.Warn, args);
+            return JSValue.undefined;
+        }
+        
+        public JSValue dir(JSValue thisBind, Arguments args)
+        {
+            LogMessage(LogLevel.Log, Tools.JSValueToObjectString(args[0]));
+            return JSValue.undefined;
+        }
+
+        //public JSValue dirxml(JSValue thisBind, Arguments args)
+        //{
+        //    return JSValue.undefined;
+        //}
+
+
+        public JSValue group(JSValue thisBind, Arguments args)
+        {
+            string label = Tools.FormatArgs(args) ?? "null";
+            if (label == "")
+                label = "console.group";
+
+            if (_groups.Count > 0)
             {
-                if (i > 0)
-                    System.Console.Error.Write(" ");
-                var r = args[i].ToString();
-                System.Console.Error.Write(r);
+                string _temp = _groups[_groups.Count - 1];
+                _groups.RemoveAt(_groups.Count - 1);
+                LogMessage(LogLevel.Info, System.String.Format(_indentGroupBegin, label));
+                _groups.Add(_temp);
             }
-            System.Console.Error.WriteLine();
+            else
+                LogMessage(LogLevel.Info, System.String.Format(_indentGroupBegin0, label));
+            
+            _groups.Add(label);
+
+            return JSValue.undefined;
+        }
+
+        public JSValue groupCollapsed(JSValue thisBind, Arguments args)
+        {
+            group(thisBind, args);
+            return JSValue.undefined;
+        }
+
+        public JSValue groupEnd(JSValue thisBind, Arguments args)
+        {
+            if (_groups.Count == 0)
+                _groups.RemoveAt(_groups.Count - 1);
+            
+            return JSValue.undefined;
+        }
+
+
+        public JSValue time(JSValue thisBind, Arguments args)
+        {
+            string label = "";
+            if (args.length > 0)
+                label = (args[0] ?? "null").ToString();
+
+            if (_timers.ContainsKey(label))
+                _timers[label].Restart();
+            else
+                _timers.Add(label, Stopwatch.StartNew());
+
+            return JSValue.undefined;
+        }
+
+        public JSValue timeEnd(JSValue thisBind, Arguments args)
+        {
+            string label = "";
+            if (args.length > 0)
+                label = (args[0] ?? "null").ToString();
+
+            double elapsed = 0.0;
+            if (_timers.ContainsKey(label))
+            {
+                _timers[label].Stop();
+                elapsed = (double)_timers[label].ElapsedTicks / Stopwatch.Frequency * 1000.0;
+                _timers.Remove(label);
+            }
+            
+            if (label != "")
+                label += ": ";
+            LogMessage(LogLevel.Info, label + Tools.DoubleToString(System.Math.Round(elapsed, 10)) + "ms");
+
+            return JSValue.undefined;
+        }
+
+        
+
+        internal static List<console> _consoles;
+        internal static void AddConsole(console console)
+        {
+            if (_consoles == null)
+                _consoles = new List<console>(4);
+            _consoles.Add(console);
+        }
+        internal static void RemoveConsole(console console)
+        {
+            if (_consoles == null)
+                _consoles = new List<console>(4);
+            _consoles.Add(console);
+        }
+        public static console GetConsole(GlobalContext globalContext)
+        {
+            if (_consoles == null)
+                return null;
+            for (int i = 0; i < _consoles.Count; i++)
+            {
+                if (_consoles[i]._globalContext == globalContext)
+                    return _consoles[i];
+            }
             return null;
         }
+
+        public static JSValue CreateConsoleObject(GlobalContext globalContext)
+        {
+            return CreateConsoleObject(CreateConsole(globalContext));
+        }
+        public static JSValue CreateConsoleObject(GlobalContext globalContext, TextWriter logTw, TextWriter infoTw, TextWriter warnTw, TextWriter errorTw)
+        {
+            return CreateConsoleObject(CreateConsole(globalContext, logTw, infoTw, warnTw, errorTw));
+        }
+        public static JSValue CreateConsoleObject(console console)
+        {
+            return console.ConsoleObject;
+        }
+
+        public static console CreateConsole(GlobalContext globalContext)
+        {
+            console c = GetConsole(globalContext);
+            if (c != null)
+                return c;
+
+            c = new console(globalContext);
+            AddConsole(c);
+
+            return c;
+        }
+        public static console CreateConsole(GlobalContext globalContext, TextWriter logTw, TextWriter infoTw, TextWriter warnTw, TextWriter errorTw)
+        {
+            console c = GetConsole(globalContext);
+            if (c != null)
+            {
+                c._textWriters = new TextWriter[4] { logTw, infoTw, warnTw, errorTw };
+                return c;
+            }
+
+            c = new console(globalContext, logTw, infoTw, warnTw, errorTw);
+            AddConsole(c);
+
+            return c;
+        }
+
     }
 }
 #endif

--- a/NiL.JS/BaseLibrary/Console.cs
+++ b/NiL.JS/BaseLibrary/Console.cs
@@ -39,13 +39,11 @@ namespace NiL.JS.BaseLibrary
                 return System.Console.Out;
         }
 
-        [Hidden]
-        public void LogArguments(LogLevel level, Arguments args)
+        internal void LogArguments(LogLevel level, Arguments args)
         {
             LogArguments(level, args, 0);
         }
-        [Hidden]
-        public void LogArguments(LogLevel level, Arguments args, int argsStart)
+        internal void LogArguments(LogLevel level, Arguments args, int argsStart)
         {
             if (args == null || args.length == 0 || args.length <= argsStart)
                 return;

--- a/NiL.JS/BaseLibrary/Console.cs
+++ b/NiL.JS/BaseLibrary/Console.cs
@@ -175,6 +175,20 @@ namespace NiL.JS.BaseLibrary
             return JSValue.undefined;
         }
 
+        public JSValue asserta(Function f, JSValue sample)
+        {
+            if (sample == null || !sample.Exists)
+                sample = Boolean.True;
+
+            if (!JSObject.@is(f.Call(null), sample))
+            {
+                var message = f.ToString();
+                message = message.Substring(message.IndexOf("=>") + 2).Trim();
+                LogMessage(LogLevel.Error, message + " not equals " + sample);
+            }
+            return JSValue.undefined;
+        }
+
         public JSValue clear(JSValue thisBind, Arguments args)
         {
             _groups.Clear();

--- a/NiL.JS/BaseLibrary/Console.cs
+++ b/NiL.JS/BaseLibrary/Console.cs
@@ -103,7 +103,7 @@ namespace NiL.JS.BaseLibrary
         [Hidden]
         public void LogArguments(LogLevel level, Arguments args, int argsStart)
         {
-            if (args.length == 0 || args.length <= argsStart)
+            if (args == null || args.length == 0 || args.length <= argsStart)
                 return;
             
             LogMessage(level, Tools.FormatArgs(args.Skip(argsStart)));

--- a/NiL.JS/BaseLibrary/Console.cs
+++ b/NiL.JS/BaseLibrary/Console.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.IO;
 using NiL.JS.Core;
 using NiL.JS.Core.Interop;
-using NiL.JS.Core.Functions;
 
 #if !NETCORE
 namespace NiL.JS.BaseLibrary
@@ -16,6 +15,7 @@ namespace NiL.JS.BaseLibrary
     public class JSConsole
     {
 
+        [Hidden]
         public enum LogLevel
         {
             Log = 0,
@@ -24,66 +24,10 @@ namespace NiL.JS.BaseLibrary
             Error = 3
         }
 
-        private string _indentChar = "|   ";
-        private string _indentGroupBegin = "|---# {0}";
-        private string _indentGroupBegin0 = "# {0}";
-
-        private GlobalContext _globalContext;
-        private JSObject _obj;
-        
         private Dictionary<string, int> _counters = new Dictionary<string, int>();
         private List<string> _groups = new List<string>();
         private Dictionary<string, Stopwatch> _timers = new Dictionary<string, Stopwatch>();
 
-
-        public GlobalContext GlobalContext
-        {
-            get
-            {
-                return _globalContext;
-            }
-        }
-
-        public JSObject ConsoleObject
-        {
-            get
-            {
-                return _obj;
-            }
-        }
-
-        
-        internal JSConsole(GlobalContext globalContext)
-        {
-            this._globalContext = globalContext;
-            CreateConsoleObject();
-        }
-
-        internal void CreateConsoleObject()
-        {
-            _obj = JSObject.CreateObject();
-
-            _obj["assert"] = new ExternalFunction(this.assert);
-            //_obj["asserta"] = new ExternalFunction(this.asserta);
-            _obj["clear"] = new ExternalFunction(this.clear);
-            _obj["count"] = new ExternalFunction(this.count);
-            _obj["debug"] = new ExternalFunction(this.debug);
-            _obj["error"] = new ExternalFunction(this.error);
-            _obj["info"] = new ExternalFunction(this.info);
-            _obj["log"] = new ExternalFunction(this.log);
-            //_obj["table"] = new ExternalFunction(this.table);
-            //_obj["trace"] = new ExternalFunction(this.trace);
-            _obj["warn"] = new ExternalFunction(this.warn);
-            _obj["dir"] = new ExternalFunction(this.dir);
-            //_obj["dirxml"] = new ExternalFunction(this.dirxml);
-            
-            _obj["group"] = new ExternalFunction(this.group);
-            _obj["groupCollapsed"] = new ExternalFunction(this.groupCollapsed);
-            _obj["groupEnd"] = new ExternalFunction(this.groupEnd);
-
-            _obj["time"] = new ExternalFunction(this.time);
-            _obj["timeEnd"] = new ExternalFunction(this.timeEnd);
-        }
 
 
         [Hidden]
@@ -105,22 +49,22 @@ namespace NiL.JS.BaseLibrary
         {
             if (args == null || args.length == 0 || args.length <= argsStart)
                 return;
-            
+
             LogMessage(level, Tools.FormatArgs(args.Skip(argsStart)));
         }
         [Hidden]
         public void LogMessage(LogLevel level, string message)
         {
-            Print(level, GetLogger(level), message, _groups.Count);
+            Print(level, GetLogger(level), message, _groups.Count, "|   ");
         }
 
         [Hidden]
         public void Print(LogLevel level, TextWriter textWriter, string message)
         {
-            Print(level, textWriter, message, 0);
+            Print(level, textWriter, message, 0, "|   ");
         }
         [Hidden]
-        public void Print(LogLevel level, TextWriter textWriter, string message, int indent)
+        public void Print(LogLevel level, TextWriter textWriter, string message, int indent, string indentChar)
         {
             if (message == null || textWriter == null)
                 return;
@@ -129,7 +73,7 @@ namespace NiL.JS.BaseLibrary
             {
                 string ind = "";
                 for (int j = 0; j < indent; j++)
-                    ind += _indentChar;
+                    ind += indentChar;
 
                 int last = 0;
                 for (int i = 0; i < message.Length; i++)
@@ -149,7 +93,7 @@ namespace NiL.JS.BaseLibrary
         }
 
 
-        public JSValue assert(JSValue thisBind, Arguments args)
+        public JSValue assert(Arguments args)
         {
             if (!(bool)args[0])
                 LogArguments(LogLevel.Log, args, 1);
@@ -170,7 +114,7 @@ namespace NiL.JS.BaseLibrary
             return JSValue.undefined;
         }
 
-        public virtual JSValue clear(JSValue thisBind, Arguments args)
+        public virtual JSValue clear(Arguments args)
         {
             _groups.Clear();
             //System.Console.Clear();
@@ -178,7 +122,7 @@ namespace NiL.JS.BaseLibrary
             return JSValue.undefined;
         }
 
-        public JSValue count(JSValue thisBind, Arguments args)
+        public JSValue count(Arguments args)
         {
             string label = "";
             if (args.length > 0)
@@ -188,7 +132,7 @@ namespace NiL.JS.BaseLibrary
                 _counters.Add(label, 0);
 
             string c = Tools.Int32ToString(++_counters[label]);
-            
+
             if (label != "")
                 label += ": ";
             LogMessage(LogLevel.Info, label + c);
@@ -196,60 +140,60 @@ namespace NiL.JS.BaseLibrary
             return JSValue.undefined;
         }
 
-        public JSValue debug(JSValue thisBind, Arguments args)
+        public JSValue debug(Arguments args)
         {
             LogArguments(LogLevel.Log, args);
             return JSValue.undefined;
         }
-        
-        public JSValue error(JSValue thisBind, Arguments args)
+
+        public JSValue error(Arguments args)
         {
             LogArguments(LogLevel.Error, args);
             return JSValue.undefined;
         }
-        
-        public JSValue info(JSValue thisBind, Arguments args)
+
+        public JSValue info(Arguments args)
         {
             LogArguments(LogLevel.Info, args);
             return JSValue.undefined;
         }
-        
-        public JSValue log(JSValue thisBind, Arguments args)
+
+        public JSValue log(Arguments args)
         {
             LogArguments(LogLevel.Log, args);
             return JSValue.undefined;
         }
 
-        //public JSValue table(JSValue thisBind, Arguments args)
+        //public JSValue table(Arguments args)
         //{
         //    return JSValue.undefined;
         //}
 
-        //public JSValue trace(JSValue thisBind, Arguments args)
+        //public JSValue trace(Arguments args)
         //{
         //    return JSValue.undefined;
         //}
 
-        public JSValue warn(JSValue thisBind, Arguments args)
+        public JSValue warn(Arguments args)
         {
             LogArguments(LogLevel.Warn, args);
             return JSValue.undefined;
         }
 
-        public virtual JSValue dir(JSValue thisBind, Arguments args)
+        public virtual JSValue dir(Arguments args)
         {
             LogMessage(LogLevel.Log, Tools.JSValueToObjectString(args[0], 2));
             return JSValue.undefined;
         }
 
-        //public JSValue dirxml(JSValue thisBind, Arguments args)
+        //public JSValue dirxml(Arguments args)
         //{
         //    LogMessage(LogLevel.Log, Tools.JSValueToObjectString(args[0], 2));
         //    return JSValue.undefined;
         //}
 
 
-        public JSValue group(JSValue thisBind, Arguments args)
+        public JSValue group(Arguments args)
         {
             string label = Tools.FormatArgs(args) ?? "null";
             if (label == "")
@@ -259,33 +203,34 @@ namespace NiL.JS.BaseLibrary
             {
                 string _temp = _groups[_groups.Count - 1];
                 _groups.RemoveAt(_groups.Count - 1);
-                LogMessage(LogLevel.Info, System.String.Format(_indentGroupBegin, label));
+                LogMessage(LogLevel.Info, "|---# " + label);
+
                 _groups.Add(_temp);
             }
             else
-                LogMessage(LogLevel.Info, System.String.Format(_indentGroupBegin0, label));
-            
+                LogMessage(LogLevel.Info, "# " + label);
+
             _groups.Add(label);
 
             return JSValue.undefined;
         }
 
-        public JSValue groupCollapsed(JSValue thisBind, Arguments args)
+        public JSValue groupCollapsed(Arguments args)
         {
-            group(thisBind, args);
+            group(args);
             return JSValue.undefined;
         }
 
-        public JSValue groupEnd(JSValue thisBind, Arguments args)
+        public JSValue groupEnd(Arguments args)
         {
             if (_groups.Count == 0)
                 _groups.RemoveAt(_groups.Count - 1);
-            
+
             return JSValue.undefined;
         }
 
 
-        public JSValue time(JSValue thisBind, Arguments args)
+        public JSValue time(Arguments args)
         {
             string label = "";
             if (args.length > 0)
@@ -299,7 +244,7 @@ namespace NiL.JS.BaseLibrary
             return JSValue.undefined;
         }
 
-        public JSValue timeEnd(JSValue thisBind, Arguments args)
+        public JSValue timeEnd(Arguments args)
         {
             string label = "";
             if (args.length > 0)
@@ -312,7 +257,7 @@ namespace NiL.JS.BaseLibrary
                 elapsed = (double)_timers[label].ElapsedTicks / Stopwatch.Frequency * 1000.0;
                 _timers.Remove(label);
             }
-            
+
             if (label != "")
                 label += ": ";
             LogMessage(LogLevel.Info, label + Tools.DoubleToString(System.Math.Round(elapsed, 10)) + "ms");
@@ -320,52 +265,23 @@ namespace NiL.JS.BaseLibrary
             return JSValue.undefined;
         }
 
-        
 
-        internal static List<JSConsole> _consoles;
-        internal static void AddConsole(JSConsole console)
+        [Hidden]
+        public override bool Equals(object obj)
         {
-            if (_consoles == null)
-                _consoles = new List<JSConsole>(4);
-            _consoles.Add(console);
-        }
-        internal static void RemoveConsole(JSConsole console)
-        {
-            if (_consoles == null)
-                _consoles = new List<JSConsole>(4);
-            _consoles.Add(console);
-        }
-        public static JSConsole GetConsole(GlobalContext globalContext)
-        {
-            if (_consoles == null)
-                return null;
-            for (int i = 0; i < _consoles.Count; i++)
-            {
-                if (_consoles[i]._globalContext == globalContext)
-                    return _consoles[i];
-            }
-            return null;
+            return base.Equals(obj);
         }
 
-        public static JSValue CreateConsoleObject(GlobalContext globalContext)
+        [Hidden]
+        public override int GetHashCode()
         {
-            return CreateConsoleObject(CreateConsole(globalContext));
-        }
-        public static JSValue CreateConsoleObject(JSConsole console)
-        {
-            return console.ConsoleObject;
+            return base.GetHashCode();
         }
 
-        public static JSConsole CreateConsole(GlobalContext globalContext)
+        [Hidden]
+        public override string ToString()
         {
-            JSConsole c = GetConsole(globalContext);
-            if (c != null)
-                return c;
-
-            c = new JSConsole(globalContext);
-            AddConsole(c);
-
-            return c;
+            return base.ToString();
         }
 
     }

--- a/NiL.JS/Core/Arguments.cs
+++ b/NiL.JS/Core/Arguments.cs
@@ -224,7 +224,7 @@ namespace NiL.JS.Core
                 yield return new KeyValuePair<string, JSValue>("4", a4);
             if (callee != null && callee.Exists && (!hideNonEnum || (callee._attributes & JSValueAttributesInternal.DoNotEnumerate) == 0))
                 yield return new KeyValuePair<string, JSValue>("callee", callee);
-            if (caller != null && callee.Exists && (!hideNonEnum || (caller._attributes & JSValueAttributesInternal.DoNotEnumerate) == 0))
+            if (caller != null && caller.Exists && (!hideNonEnum || (caller._attributes & JSValueAttributesInternal.DoNotEnumerate) == 0))
                 yield return new KeyValuePair<string, JSValue>("caller", caller);
             if (_lengthContainer != null && _lengthContainer.Exists && (!hideNonEnum || (_lengthContainer._attributes & JSValueAttributesInternal.DoNotEnumerate) == 0))
                 yield return new KeyValuePair<string, JSValue>("length", _lengthContainer);

--- a/NiL.JS/Core/GlobalContext.cs
+++ b/NiL.JS/Core/GlobalContext.cs
@@ -89,7 +89,7 @@ namespace NiL.JS.Core
                 DefineConstructor(typeof(SyntaxError));
                 DefineConstructor(typeof(RegExp));
 #if !(PORTABLE || NETCORE)
-                DefineVariable("console").Assign(JSConsole.CreateConsoleObject(this));
+                DefineVariable("console").Assign(JSValue.Marshal(new JSConsole()));
 #endif
                 DefineConstructor(typeof(ArrayBuffer));
                 DefineConstructor(typeof(Int8Array));

--- a/NiL.JS/Core/GlobalContext.cs
+++ b/NiL.JS/Core/GlobalContext.cs
@@ -89,7 +89,7 @@ namespace NiL.JS.Core
                 DefineConstructor(typeof(SyntaxError));
                 DefineConstructor(typeof(RegExp));
 #if !(PORTABLE || NETCORE)
-                DefineConstructor(typeof(console));
+                DefineVariable("console").Assign(console.CreateConsoleObject(this));
 #endif
                 DefineConstructor(typeof(ArrayBuffer));
                 DefineConstructor(typeof(Int8Array));

--- a/NiL.JS/Core/GlobalContext.cs
+++ b/NiL.JS/Core/GlobalContext.cs
@@ -89,7 +89,7 @@ namespace NiL.JS.Core
                 DefineConstructor(typeof(SyntaxError));
                 DefineConstructor(typeof(RegExp));
 #if !(PORTABLE || NETCORE)
-                DefineVariable("console").Assign(console.CreateConsoleObject(this));
+                DefineVariable("console").Assign(JSConsole.CreateConsoleObject(this));
 #endif
                 DefineConstructor(typeof(ArrayBuffer));
                 DefineConstructor(typeof(Int8Array));

--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -1917,7 +1917,9 @@ namespace NiL.JS.Core
                     BaseLibrary.Function f = v.Value as BaseLibrary.Function;
                     if (recursionDepth >= maxRecursionDepth)
                         return f.name + "()";
-                    return f.ToString(true);
+                    if (recursionDepth == maxRecursionDepth - 1)
+                        return f.ToString(true);
+                    return f.ToString();
                 case JSValueType.Object:
                     if (v == null || v._oValue == null)
                         return "null";
@@ -2063,8 +2065,10 @@ namespace NiL.JS.Core
                             s.Append(args[used++].ToString());
                             break;
                         case 'o':
+                            s.Append(Tools.JSValueToObjectString(args[used++], 1));
+                            break;
                         case 'O':
-                            s.Append(Tools.JSValueToObjectString(args[used++]));
+                            s.Append(Tools.JSValueToObjectString(args[used++], 2));
                             break;
                         case 'i':
                         case 'd':

--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -1917,7 +1917,7 @@ namespace NiL.JS.Core
                     BaseLibrary.Function f = v.Value as BaseLibrary.Function;
                     if (recursionDepth >= maxRecursionDepth)
                         return f.name + "()";
-                    return $"function {f.name}()";
+                    return f.ToString(true);
                 case JSValueType.Object:
                     if (v == null || v._oValue == null)
                         return "null";

--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -2001,18 +2001,33 @@ namespace NiL.JS.Core
                         return v.ToString();
 
                     if (v.Value is BaseLibrary.Array
-                        || v.Value == Context.CurrentBaseContext.GetPrototype(typeof(BaseLibrary.Array)))
+                        || v.Value == Context.CurrentBaseContext.GetPrototype(typeof(BaseLibrary.Array))
+                        || v == Context.CurrentBaseContext.GetPrototype(typeof(BaseLibrary.Array)))
                     {
                         BaseLibrary.Array a = v.Value as BaseLibrary.Array;
-                        if (a == null)
-                            return v.ToString();
+                        StringBuilder s;
+
+                        if (a == null) // v == Array.prototype
+                        {
+                            s = new StringBuilder("Array [ ");
+                            int j = 0;
+                            for (var e = v.GetEnumerator(true, EnumerationMode.RequireValues); e.MoveNext();)
+                            {
+                                if (j++ > 0)
+                                    s.Append(", ");
+                                s.Append(e.Current.Key).Append(": ");
+                                s.Append(Tools.JSValueToObjectString(e.Current.Value, maxRecursionDepth, recursionDepth + 1));
+                            }
+                            s.Append(" ]");
+                            return s.ToString();
+                        }
 
                         long len = (long)a.length;
 
                         if (recursionDepth >= maxRecursionDepth)
                             return $"Array[{len}]";
 
-                        StringBuilder s = new StringBuilder($"Array ({len}) [ ");
+                        s = new StringBuilder($"Array ({len}) [ ");
                         int i = 0;
                         for (i = 0; i < len; i++)
                         {

--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -1986,13 +1986,15 @@ namespace NiL.JS.Core
                     return "Date " + dstr;
                 case JSValueType.Function:
                     BaseLibrary.Function f = v.Value as BaseLibrary.Function;
+                    if (f == null)
+                        return v.ToString();
                     if (recursionDepth >= maxRecursionDepth)
                         return f.name + "()";
                     if (recursionDepth == maxRecursionDepth - 1)
                         return f.ToString(true);
                     return f.ToString();
                 case JSValueType.Object:
-                    if (v == null || v._oValue == null)
+                    if (v._oValue == null)
                         return "null";
 
                     if (v.Value is RegExp)
@@ -2002,6 +2004,9 @@ namespace NiL.JS.Core
                         || v.Value == Context.CurrentBaseContext.GetPrototype(typeof(BaseLibrary.Array)))
                     {
                         BaseLibrary.Array a = v.Value as BaseLibrary.Array;
+                        if (a == null)
+                            return v.ToString();
+
                         long len = (long)a.length;
 
                         if (recursionDepth >= maxRecursionDepth)
@@ -2041,8 +2046,10 @@ namespace NiL.JS.Core
                         JSObject o = v as JSObject;
                         if (o == null)
                             o = v._oValue as JSObject;
+                        if (o == null)
+                            return v.ToString();
 
-                        
+
                         int i = 0;
                         for (var e = o.GetEnumerator(true, EnumerationMode.RequireValues); e.MoveNext();)
                         {

--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -1936,10 +1936,7 @@ namespace NiL.JS.Core
                         return v.Value.GetType().Name;
                     }
                 case JSValueType.Function:
-                    {
-                        (v as Function).ToString();
-                        break;
-                    }
+                    return "Function";
                 case JSValueType.Date:
                     return "Date";
                 case JSValueType.Property:
@@ -1961,11 +1958,6 @@ namespace NiL.JS.Core
                 default:
                     throw new NotImplementedException();
             }
-
-            string typeName = v.toString(null).ToString(); // "[object TYPENAME]"
-            typeName = typeName.Substring(8, typeName.Length - 1 - 8); // 8 = "[object ".Length
-            
-                return typeName;
         }
 
         public static string JSValueToObjectString(JSValue v)

--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -2081,7 +2081,7 @@ namespace NiL.JS.Core
         }
 
 
-        public static string FormatArgs(IEnumerable args)
+        public static string FormatArgs(IEnumerable<KeyValuePair<string, JSValue>> args)
         {
             if (args == null)
                 return null;
@@ -2090,17 +2090,11 @@ namespace NiL.JS.Core
             if (!e.MoveNext())
                 return null;
 
-            var o = e.Current;
-            JSValue v = o as JSValue;
+            var arg = e.Current.Value;
             string f = null;
 
-            if (o != null)
-            {
-                if (o is string || o is System.String)
-                    f = o.ToString();
-                else if (v != null && v.ValueType == JSValueType.String)
-                    f = v.ToString();
-            }
+            if (arg != null && arg.ValueType == JSValueType.String)
+                f = arg.ToString();
 
             bool hasNext = e.MoveNext();
             
@@ -2111,7 +2105,7 @@ namespace NiL.JS.Core
                 int pos = 0;
                 while (pos < f.Length && hasNext)
                 {
-                    v = (o = e.Current) as JSValue;
+                    arg = e.Current.Value;
                     bool usedArg = false;
 
                     int next = f.IndexOf('%', pos);
@@ -2155,36 +2149,18 @@ namespace NiL.JS.Core
                     switch (c)
                     {
                         case 's':
-                            if (v != null)
-                                s.Append(Tools.JSValueToString(v));
-                            else if (o == null)
-                                s.Append("null");
-                            else
-                            {
-                                if (o is System.String || o is System.Char)
-                                    s.Append('"').Append(o.ToString()).Append('"');
-                                else
-                                    s.Append(o.ToString());
-                            }
+                            s.Append(Tools.JSValueToString(arg));
                             usedArg = true;
                             break;
                         case 'o':
                         case 'O':
                             int maxRec = (c == 'o') ? 1 : 2;
-                            if (v != null)
-                                s.Append(Tools.JSValueToObjectString(v, maxRec));
-                            else
-                                s.Append((o ?? null).ToString()); // maybe list all properties + methods
-
+                            s.Append(Tools.JSValueToObjectString(arg, maxRec));
                             usedArg = true;
                             break;
                         case 'i':
                         case 'd':
-                            d = double.NaN;
-                            if (v != null)
-                                d = (double)Tools.JSObjectToNumber(v);
-                            else
-                                double.TryParse((o ?? "null").ToString(), out d);
+                            d = (double)Tools.JSObjectToNumber(arg);
 
                             if (double.IsNaN(d) || double.IsInfinity(d))
                                 d = 0.0;
@@ -2200,11 +2176,7 @@ namespace NiL.JS.Core
                             usedArg = true;
                             break;
                         case 'f':
-                            d = double.NaN;
-                            if (v != null)
-                                d = (double)Tools.JSObjectToNumber(v);
-                            else
-                                double.TryParse((o ?? "null").ToString(), out d);
+                            d = (double)Tools.JSObjectToNumber(arg);
 
                             if (para >= 0)
                                 d = System.Math.Round(d, System.Math.Min(15, para));
@@ -2235,36 +2207,46 @@ namespace NiL.JS.Core
 
                 while (hasNext)
                 {
-                    v = e.Current as JSValue;
+                    arg = e.Current.Value;
                     s.Append(' ');
-                    if (v != null)
+                    if (arg != null)
                     {
-                        if (v.ValueType == JSValueType.Object)
-                            s.Append(Tools.JSValueToObjectString(v));
+                        if (arg.ValueType == JSValueType.Object)
+                            s.Append(Tools.JSValueToObjectString(arg));
                         else
-                            s.Append(v.ToString());
+                            s.Append(arg.ToString());
                     }
                     else
-                        s.Append((e.Current ?? "null").ToString());
+                        s.Append("null");
                     hasNext = e.MoveNext();
                 }
             }
             else
             {
-                e.Reset();
-                while (e.MoveNext())
+                if (arg != null)
                 {
-                    v = e.Current as JSValue;
+                    if (arg.ValueType == JSValueType.Object)
+                        s.Append(Tools.JSValueToObjectString(arg));
+                    else
+                        s.Append(arg.ToString());
+                }
+                else
+                    s.Append("null");
+
+                while (hasNext)
+                {
+                    arg = e.Current.Value;
                     s.Append(' ');
-                    if (v != null)
+                    if (arg != null)
                     {
-                        if (v.ValueType == JSValueType.Object)
-                            s.Append(Tools.JSValueToObjectString(v));
+                        if (arg.ValueType == JSValueType.Object)
+                            s.Append(Tools.JSValueToObjectString(arg));
                         else
-                            s.Append(v.ToString());
+                            s.Append(arg.ToString());
                     }
                     else
-                        s.Append((e.Current ?? "null").ToString());
+                        s.Append("null");
+                    hasNext = e.MoveNext();
                 }
             }
 

--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -2082,7 +2082,7 @@ namespace NiL.JS.Core
             return v.ToString();
         }
 
-        public static string JSValueToString(JSValue v)
+        internal static string JSValueToString(JSValue v)
         {
             if (v == null)
                 return "null";
@@ -2103,7 +2103,7 @@ namespace NiL.JS.Core
         }
 
 
-        public static string FormatArgs(IEnumerable args)
+        internal static string FormatArgs(IEnumerable args)
         {
             if (args == null)
                 return null;

--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -1991,6 +1991,27 @@ namespace NiL.JS.Core
             return v.ToString();
         }
         
+        public static string JSValueToString(JSValue v)
+        {
+            if (v == null)
+                return "null";
+
+            if (v.ValueType == JSValueType.Object)
+            {
+                if (v._oValue == null)
+                    return "null";
+
+                var o = v as ObjectWrapper;
+                if (o == null)
+                    o = v._oValue as ObjectWrapper;
+                if (o != null)
+                    return o.Value.ToString();
+            }
+
+            return v.ToString();
+        }
+
+
         public static string FormatArgs(Arguments args)
         {
             return FormatArgs(args, 0, args.length, true);
@@ -2062,7 +2083,7 @@ namespace NiL.JS.Core
                     switch (c)
                     {
                         case 's':
-                            s.Append(args[used++].ToString());
+                            s.Append(Tools.JSValueToString(args[used++]));
                             break;
                         case 'o':
                             s.Append(Tools.JSValueToObjectString(args[used++], 1));

--- a/NiL.JS/Expressions/FunctionDefinition.cs
+++ b/NiL.JS/Expressions/FunctionDefinition.cs
@@ -873,10 +873,11 @@ namespace NiL.JS.Expressions
                     code.Append(parameters[i])
                         .Append(++i < parameters.Length ? "," : "");
 
-            code.Append(") ");
+            code.Append(")");
 
             if (!headerOnly)
             {
+                code.Append(" ");
                 if (kind == FunctionKind.Arrow)
                     code.Append("=> ");
 


### PR DESCRIPTION
# Improved console
I create an improved console modelled after the [Console Living Standard](https://console.spec.whatwg.org/).

## New JS functions
info, warn, debug, dir, clear, count, time, timeEnd, group, groupCollapsed, groupEnd

## Format specifiers
console now supports [Format specifiers](https://console.spec.whatwg.org/#formatting-specifiers) (This does not include %c). Further information can be found [here](https://developer.mozilla.org/de/docs/Web/API/Console#Using_string_substitutions) and [here](https://developers.google.com/web/tools/chrome-devtools/console/console-write#string_substitution_and_formatting).
Examples:
```js
var a = [1, 4.5, "abc", [1, 2], Array];

for (var i=0; i<a.length; i++)
    console.log("%d: %s", i, a[i]);
// 0: 1
// 1: 4.5
// 2: abc
// 3: 1,2
// 4: function Array() { [native code] }

for (var i=0; i<a.length; i++)
    console.log("%d: %d", i, a[i]);
// 0: 1
// 1: 4
// 2: 0
// 3: 0
// 4: 0

for (var i=0; i<a.length; i++)
    console.log("%d: %f", i, a[i]);
// 0: 1
// 1: 4.5
// 2: NaN
// 3: NaN
// 4: NaN

for (var i=0; i<a.length; i++)
    console.log("%d: %o", i, a[i]);
// 0: 1
// 1: 4.5
// 2: "abc"
// 3: Array (2) [ 1, 2 ]
// 4: function Array()

console.log("%d", Math.PI); // 3
console.log("%f", Math.PI); // 3.141592653589793
console.log("%.0f", Math.PI); // 3
console.log("%.2f", Math.PI); // 3.14
```

As a consequence function like log no longer simple output `[JSValue].ToString()`. Objects and Arrays will now display content and JS properties (using `Tools.JSValueToObjectString`), instead of displaying `[object Object]`.
Examples:
```js
var a = [1, "foo", new RegExp("[a-z]", "i")];
var obj = {bar: "bar", a: a};
console.log(a); // Array (3) [ 1, "foo", /[a-z]/i ]
console.log(obj); // Object { bar: "bar", a: Array[3] }
obj.obj = Object;
console.log("obj = ", obj); // obj = Object { bar: "bar", a: Array[3], obj: Object() }
```
Selfreferencial objects (and objects with object properties) are handled by only allowing a certain recursion depth before switching to a simplefied version that does not display content and properties. The default value for this maximal recursion depth is 1.
```js
var o = {};
o.o = o;
console.log(o); // Object { o: Object }
```

## Internal workings
count, time and group each need to store variables under a certain label. This makes it impractical to use static variables because different scripts could influence each other.
Because of this console is no longer a static class. Each instance of console is now tied to one GlobalContext (`CreateConsole `should be used over `new console`). `GlobalContext.ResetContext()` will automatically add a new console like before.
An instance of console will hold not only the variables for count, time and group but also the TextWriters to which the console will write, so different consoles can output to different TextWriters. (The default TextWriters will be `Console.Out` and `Console.Error`)

However, a console object is not directly passed to its GlobalContext. Instead a JSObject will be created that has all console functions (like log, error, etc.) but no other functions (like LogMessage).

