### PR TITLE
JSConsole update

### DIFF
--- a/NiL.JS/BaseLibrary/Console.cs
+++ b/NiL.JS/BaseLibrary/Console.cs
@@ -192,11 +192,10 @@ namespace NiL.JS.BaseLibrary
             if (_lineSplitter == null)
                 _lineSplitter = new Regex("\r\n?|\n");
 
-            var __a = args[0];
-            if (__a == null)
+            if (args[0] == null)
                 return log(args);
 
-            var a = __a.Value as BaseLibrary.Array;
+            var a = args[0].Value as BaseLibrary.Array;
             if (a == null)
                 return log(args);
 
@@ -206,10 +205,9 @@ namespace NiL.JS.BaseLibrary
 
 
             HashSet<string> filter = null;
-            __a = args[1];
-            if (__a != null)
+            if (args[1] != null)
             {
-                var f = __a.Value as BaseLibrary.Array;
+                var f = args[1].Value as BaseLibrary.Array;
                 if (f != null && (int)f.length > 0)
                 {
                     filter = new HashSet<string>();
@@ -232,12 +230,12 @@ namespace NiL.JS.BaseLibrary
                     continue;
 
                 var d = new Dictionary<string, string[]>();
-                for (var e = item.GetEnumerator(); e.MoveNext();)
+                foreach (var prop in item)
                 {
-                    if (filter != null && !filter.Contains(e.Current.Key))
+                    if (filter != null && !filter.Contains(prop.Key))
                         continue;
 
-                    string colName = e.Current.Key ?? "";
+                    string colName = prop.Key ?? "";
 
                     if (!cols.ContainsKey(colName))
                         cols.Add(colName, colName.Length);
@@ -245,7 +243,7 @@ namespace NiL.JS.BaseLibrary
                     int colWidth = cols[colName];
                     int colMaxWidth = System.Math.Max(cols[colName], _tableMaxColWidth);
 
-                    string[] splits = _lineSplitter.Split(Tools.JSValueToObjectString(e.Current.Value, 0));
+                    string[] splits = _lineSplitter.Split(Tools.JSValueToObjectString(prop.Value, 0));
                     var lines = new List<string>(splits.Length);
                     foreach (var line in splits)
                     {
@@ -267,7 +265,7 @@ namespace NiL.JS.BaseLibrary
                     }
 
                     cols[colName] = colWidth;
-                    d.Add(e.Current.Key, lines.ToArray());
+                    d.Add(prop.Key, lines.ToArray());
                 }
 
                 indexWidth = System.Math.Max(indexWidth, i.ToString().Length);
@@ -278,7 +276,7 @@ namespace NiL.JS.BaseLibrary
             if (rows.Count == 0 || cols.Count == 0)
                 return log(args);
 
-            List<string> colsN = new List<string>(new string[] { indexName });
+            List<string> colsN = new List<string> { indexName };
             if (filter != null)
                 colsN.AddRange(filter.Where((x) => cols.ContainsKey(x)));
             else
@@ -383,8 +381,6 @@ namespace NiL.JS.BaseLibrary
             {
                 if (c._parent == null) // GlobalContext
                     break;
-                if (i++ > Context.MaxConcurentContexts) // prevent infinite loops
-                    ExceptionHelper.Throw(new Error("Unable to trace back to root."));
 
                 Function owner = c._owner;
                 if (owner == null)
@@ -458,12 +454,12 @@ namespace NiL.JS.BaseLibrary
 
         public virtual JSValue groupCollapsed(Arguments args)
         {
-            return group(args); ;
+            return group(args);
         }
 
         public virtual JSValue groupEnd(Arguments args)
         {
-            if (_groups.Count == 0)
+            if (_groups.Count > 0)
                 _groups.RemoveAt(_groups.Count - 1);
 
             return JSValue.undefined;

--- a/NiL.JS/BaseLibrary/Console.cs
+++ b/NiL.JS/BaseLibrary/Console.cs
@@ -207,11 +207,9 @@ namespace NiL.JS.BaseLibrary
 
             HashSet<string> filter = null;
             __a = args[1];
-            System.Console.WriteLine(__a);
             if (__a != null)
             {
                 var f = __a.Value as BaseLibrary.Array;
-                System.Console.WriteLine(f);
                 if (f != null && (int)f.length > 0)
                 {
                     filter = new HashSet<string>();

--- a/NiL.JS/BaseLibrary/Console.cs
+++ b/NiL.JS/BaseLibrary/Console.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 using NiL.JS.Core;
 using NiL.JS.Core.Interop;
 
@@ -14,6 +16,7 @@ namespace NiL.JS.BaseLibrary
     /// </summary>
     public class JSConsole
     {
+
         [Hidden]
         public enum LogLevel
         {
@@ -23,9 +26,32 @@ namespace NiL.JS.BaseLibrary
             Error = 3
         }
 
+        private static Regex _lineSplitter;
+
         private Dictionary<string, int> _counters = new Dictionary<string, int>();
         private List<string> _groups = new List<string>();
         private Dictionary<string, Stopwatch> _timers = new Dictionary<string, Stopwatch>();
+
+        private int _tableMaxColWidth = 100;
+
+        /// <summary>
+        /// This controls in part the maximum width (in chars) that a column printed by table can have.
+        /// The actual maximum width is the maximum of this value and the length of the columns header (the name of the property displayed).
+        /// </summary>
+        [Hidden]
+        public virtual int TableMaximumColumnWidth
+        {
+            get
+            {
+                return _tableMaxColWidth;
+            }
+            set
+            {
+                if (value <= 0)
+                    ExceptionHelper.Throw(new RangeError("TableMaximumColumnWidth needs to be at least 1"));
+                _tableMaxColWidth = value;
+            }
+        }
 
         [Hidden]
         public virtual TextWriter GetLogger(LogLevel ll)
@@ -137,7 +163,7 @@ namespace NiL.JS.BaseLibrary
             return JSValue.undefined;
         }
 
-        public JSValue debug(Arguments args)
+        public virtual JSValue debug(Arguments args)
         {
             LogArguments(LogLevel.Log, args);
             return JSValue.undefined;
@@ -161,15 +187,237 @@ namespace NiL.JS.BaseLibrary
             return JSValue.undefined;
         }
 
-        //public JSValue table(Arguments args)
-        //{
-        //    return JSValue.undefined;
-        //}
+        public virtual JSValue table(Arguments args)
+        {
+            if (_lineSplitter == null)
+                _lineSplitter = new Regex("\r\n?|\n");
 
-        //public JSValue trace(Arguments args)
-        //{
-        //    return JSValue.undefined;
-        //}
+            var __a = args[0];
+            if (__a == null)
+                return log(args);
+
+            var a = __a.Value as BaseLibrary.Array;
+            if (a == null)
+                return log(args);
+
+            int len = (int)a.length;
+            if (len == 0)
+                return log(args);
+
+
+            HashSet<string> filter = null;
+            __a = args[1];
+            System.Console.WriteLine(__a);
+            if (__a != null)
+            {
+                var f = __a.Value as BaseLibrary.Array;
+                System.Console.WriteLine(f);
+                if (f != null && (int)f.length > 0)
+                {
+                    filter = new HashSet<string>();
+                    int fLen = (int)f.length;
+                    for (int i = 0; i < fLen; i++)
+                        filter.Add(Tools.JSValueToString(f[i]));
+                }
+            }
+
+
+            var cols = new SortedDictionary<string, int>(); // name of col -> its width
+            var rows = new List<Dictionary<string, string[]>>(); // name of cols -> its data as lines of string
+            string indexName = "(index)";
+            int indexWidth = indexName.Length;
+
+            for (int i = 0; i < len; i++)
+            {
+                var item = a[i];
+                if (item == null || item._valueType != JSValueType.Object)
+                    continue;
+
+                var d = new Dictionary<string, string[]>();
+                for (var e = item.GetEnumerator(); e.MoveNext();)
+                {
+                    if (filter != null && !filter.Contains(e.Current.Key))
+                        continue;
+
+                    string colName = e.Current.Key ?? "";
+
+                    if (!cols.ContainsKey(colName))
+                        cols.Add(colName, colName.Length);
+
+                    int colWidth = cols[colName];
+                    int colMaxWidth = System.Math.Max(cols[colName], _tableMaxColWidth);
+
+                    string[] splits = _lineSplitter.Split(Tools.JSValueToObjectString(e.Current.Value, 0));
+                    var lines = new List<string>(splits.Length);
+                    foreach (var line in splits)
+                    {
+                        if (line.Length <= colMaxWidth)
+                        {
+                            colWidth = System.Math.Max(colWidth, line.Length);
+                            lines.Add(line);
+                        }
+                        else
+                        {
+                            colWidth = colMaxWidth;
+                            int p = 0;
+                            while (p < line.Length)
+                            {
+                                lines.Add(line.Substring(p, System.Math.Min(colWidth, line.Length - p)));
+                                p += lines.Last().Length;
+                            }
+                        }
+                    }
+
+                    cols[colName] = colWidth;
+                    d.Add(e.Current.Key, lines.ToArray());
+                }
+
+                indexWidth = System.Math.Max(indexWidth, i.ToString().Length);
+                d.Add(indexName, new string[] { i.ToString() });
+                rows.Add(d);
+            }
+
+            if (rows.Count == 0 || cols.Count == 0)
+                return log(args);
+
+            List<string> colsN = new List<string>(new string[] { indexName });
+            if (filter != null)
+                colsN.AddRange(filter.Where((x) => cols.ContainsKey(x)));
+            else
+                colsN.AddRange(cols.Select((x) => x.Key));
+            cols.Add(indexName, indexWidth);
+            int columns = colsN.Count;
+
+            var s = new StringBuilder();
+
+            // top line
+            s.Append("+-");
+            for (int i = 0; i < columns; i++)
+            {
+                if (i > 0)
+                    s.Append("-+-");
+                int colWidth = cols[colsN[i]];
+                s.Append(new string('-', colWidth));
+            }
+            s.Append("-+\n");
+
+            // header
+            s.Append("| ");
+            for (int i = 0; i < columns; i++)
+            {
+                if (i > 0)
+                    s.Append(" | ");
+                int colWidth = cols[colsN[i]];
+                s.Append(colsN[i].PadRight(colWidth));
+            }
+            s.Append(" |\n");
+
+            // middle line
+            s.Append("+-");
+            for (int i = 0; i < columns; i++)
+            {
+                if (i > 0)
+                    s.Append("-+-");
+                s.Append(new string('-', cols[colsN[i]]));
+            }
+            s.Append("-+\n");
+
+            // body
+            for (int r = 0; r < rows.Count; r++)
+            {
+                var row = rows[r];
+                bool hasNextLine = true;
+                int offset = 0;
+                while (hasNextLine)
+                {
+                    hasNextLine = false;
+
+                    s.Append("| ");
+                    for (int i = 0; i < columns; i++)
+                    {
+                        if (i > 0)
+                            s.Append(" | ");
+                        string colName = colsN[i];
+                        int colWidth = cols[colName];
+                        string line = "";
+
+                        if (row.ContainsKey(colName))
+                        {
+                            var lines = row[colName];
+                            if (offset < lines.Length)
+                                line = lines[offset];
+                            if (lines.Length > offset + 1)
+                                hasNextLine = true;
+                        }
+
+                        s.Append(line.PadRight(colWidth));
+                    }
+                    s.Append(" |\n");
+
+                    offset++;
+                }
+            }
+
+            // bottom line
+            s.Append("+-");
+            for (int i = 0; i < colsN.Count; i++)
+            {
+                if (i > 0)
+                    s.Append("-+-");
+                s.Append(new string('-', cols[colsN[i]]));
+            }
+            s.Append("-+");
+
+
+            LogMessage(LogLevel.Log, s.ToString());
+
+            return JSValue.undefined;
+        }
+
+        public JSValue trace(Arguments args)
+        {
+            Context c = Context.CurrentContext;
+
+            StringBuilder s = new StringBuilder();
+
+            int i = 0;
+            while (c != null)
+            {
+                if (c._parent == null) // GlobalContext
+                    break;
+                if (i++ > Context.MaxConcurentContexts) // prevent infinite loops
+                    ExceptionHelper.Throw(new Error("Unable to trace back to root."));
+
+                Function owner = c._owner;
+                if (owner == null)
+                    break;
+
+                if (i > 1)
+                    s.AppendLine();
+
+                s.Append(owner.name);
+                if (owner._functionDefinition != null)
+                {
+                    if (owner._functionDefinition.Length > 0)
+                        s.Append(" @" + owner._functionDefinition.Position);
+                }
+
+                c = c._parent;
+            }
+
+            if (args != null && args.length > 0)
+            {
+                group(args);
+                LogMessage(LogLevel.Log, s.ToString());
+                groupEnd(args);
+            }
+            else
+            {
+                LogMessage(LogLevel.Log, s.ToString());
+            }
+
+            return JSValue.undefined;
+        }
 
         public JSValue warn(Arguments args)
         {
@@ -183,16 +431,15 @@ namespace NiL.JS.BaseLibrary
             return JSValue.undefined;
         }
 
-        //public JSValue dirxml(Arguments args)
-        //{
-        //    LogMessage(LogLevel.Log, Tools.JSValueToObjectString(args[0], 2));
-        //    return JSValue.undefined;
-        //}
-
-        public JSValue group(Arguments args)
+        public virtual JSValue dirxml(Arguments args)
         {
-            string label = Tools.FormatArgs(args) ?? "null";
-            if (label == "")
+            return dir(args);
+        }
+
+        public virtual JSValue group(Arguments args)
+        {
+            string label = Tools.FormatArgs(args);
+            if (string.IsNullOrEmpty(label))
                 label = "console.group";
 
             if (_groups.Count > 0)
@@ -211,13 +458,12 @@ namespace NiL.JS.BaseLibrary
             return JSValue.undefined;
         }
 
-        public JSValue groupCollapsed(Arguments args)
+        public virtual JSValue groupCollapsed(Arguments args)
         {
-            group(args);
-            return JSValue.undefined;
+            return group(args); ;
         }
 
-        public JSValue groupEnd(Arguments args)
+        public virtual JSValue groupEnd(Arguments args)
         {
             if (_groups.Count == 0)
                 _groups.RemoveAt(_groups.Count - 1);
@@ -277,5 +523,6 @@ namespace NiL.JS.BaseLibrary
         {
             return base.ToString();
         }
+
     }
 }


### PR DESCRIPTION
# JSConsole update

This now completes the implementation of the standard. (kind of)

## New functions

dirxml (alias for dir), table, trace

## Changed functions

group
Plus some functions are now `virtual`.

## Table

`table` will print all properties of _similar_ objects. The objects have to be passed in an array as the first argument of `table`. The array will be processed in order. Non-objects entry will be ignored.
The second argument is an optional filter.
If the first argument is not an array, does not have entries, does not contain objects or the function is unable to gather data then `table` will be an alias for `log`. 
Examples:

```js
console.table([ {a: 1, b: 6}, {a: "foo", bar: null}, 6, new Date(), {a: 1, b: /abc/i, bar: [1,2]} ]);
```

Output:

```
+---------+-------+--------+----------+
| (index) | a     | b      | bar      |   <- note that the columns are in alphabetical order
+---------+-------+--------+----------+
| 0       | 1     | 6      |          |
| 1       | "foo" |        | null     |   <- "foo" because values are formatted using JSValueToObjectString
| 4       | 1     | /abc/i | Array[2] |   <- non-objects were skipped
+---------+-------+--------+----------+
```

With filter:

```js
console.table(
    [ {a: 1, b: 6}, {a: "foo", bar: null}, 6, new Date(), {a: 1, b: /abc/i, bar: [1,2]} ],
    ["bar", "a", "c"]
);
```

Output:

```
+---------+----------+-------+
| (index) | bar      | a     |   <- note that the columns are in the order of the filter 
+---------+----------+-------+      but not occurring properties are missing
| 0       |          | 1     |
| 1       | null     | "foo" |
| 4       | Array[2] | 1     |
+---------+----------+-------+
```

Each JSConsole instance will now also have a new property: `int TableMaximumColumnWidth = 100`. This controls in part the maximum width (in chars) that a column printed by `table` can have. The actual maximum width is the maximum of this value and the length of the column's header (the name of the property displayed).

## Trace

This will print the current function stack and the position of the function in the source code (currently it's only the position of the first char of the function definition). Example:

```js
function f() {
    function g() {
        console.trace();
    };
    g();
};
f();
```

Output:

```
g @20
f @0
anonymous
```