### PR TITLE
JSValueToObjectString Update

### DIFF
--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
@@ -2037,12 +2037,39 @@ namespace NiL.JS.Core
 
                         s = new StringBuilder($"Array ({len}) [ ");
                         int i = 0;
+                        int undefs = 0;
                         for (i = 0; i < len; i++)
                         {
-                            if (i > 0)
-                                s.Append(", ");
-                            s.Append(Tools.JSValueToObjectString(a[i], maxRecursionDepth, recursionDepth + 1));
+                            var val = a[i];
+                            if (undefs > 1)
+                            {
+                                if (val != null && val._valueType <= JSValueType.Undefined)
+                                    undefs++;
+                                else
+                                {
+                                    s.Append(" x ").Append(undefs);
+                                    s.Append(", ");
+                                    s.Append(Tools.JSValueToObjectString(val, maxRecursionDepth, recursionDepth + 1));
+                                    undefs = 0;
+                                }
+                            }
+                            else
+                            {
+                                if (val != null && val._valueType <= JSValueType.Undefined)
+                                {
+                                    if (++undefs > 1)
+                                        continue;
+                                }
+                                else
+                                    undefs = 0;
+                                if (i > 0)
+                                    s.Append(", ");
+                                s.Append(Tools.JSValueToObjectString(val, maxRecursionDepth, recursionDepth + 1));
+                            }
                         }
+                        if (undefs > 0)
+                            s.Append(" x ").Append(undefs);
+
                         if (a._fields != null)
                         {
                             for (var e = a._fields.GetEnumerator(); e.MoveNext();)


### PR DESCRIPTION
A little update for JSValueToObjectString.
Arrays with long sequences of undefined will now be printed more compact.
Examples:
```js
console.log(new Array(1)); // Array (1) [ undefined ]
console.log(new Array(2)); // Array (2) [ undefined x 2 ]
console.log(new Array(1000)); // Array (1000) [ undefined x 1000 ]

var a = new Array(100);
a[100] = "abc";
console.log(a); // Array (101) [ undefined x 100, "abc" ]
```