### PR TITLE
Text processing

### DIFF
--- a/NiL.JS/BaseLibrary/Array.cs
+++ b/NiL.JS/BaseLibrary/Array.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -67,6 +67,15 @@ namespace NiL.JS.BaseLibrary
             if (length > 0)
                 _data[(int)((uint)length - 1)] = null;
 
+            _attributes |= JSValueAttributesInternal.SystemObject;
+        }
+
+        [DoNotEnumerate]
+        internal Array(JSValue[] data)
+        {
+            _oValue = this;
+            _valueType = JSValueType.Object;
+            _data = new SparseArray<JSValue>(data);
             _attributes |= JSValueAttributesInternal.SystemObject;
         }
 

--- a/NiL.JS/BaseLibrary/Array.cs
+++ b/NiL.JS/BaseLibrary/Array.cs
@@ -915,14 +915,14 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(1)]
         public static JSValue join(JSValue self, Arguments args)
         {
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("Array.prototype.join called for null or undefined"));
+
             return joinImpl(self, args == null || args.length == 0 || !args[0].Defined ? "," : args[0].ToString(), false);
         }
 
         private static string joinImpl(JSValue self, string separator, bool locale)
         {
-            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
-                ExceptionHelper.Throw(new TypeError("Array.prototype.join called for null or undefined"));
-
             var selfA = self.Value as Array;
             selfA = selfA ?? Tools.arraylikeToArray(self, true, false, false, -1);
 

--- a/NiL.JS/BaseLibrary/Array.cs
+++ b/NiL.JS/BaseLibrary/Array.cs
@@ -62,7 +62,6 @@ namespace NiL.JS.BaseLibrary
                 _data[(int)((uint)length - 1)] = null;
         }
 
-        [DoNotEnumerate]
         internal Array(JSValue[] data)
         {
             _oValue = this;

--- a/NiL.JS/BaseLibrary/Array.cs
+++ b/NiL.JS/BaseLibrary/Array.cs
@@ -994,12 +994,7 @@ namespace NiL.JS.BaseLibrary
             if (args == null || args.Length == 0)
                 return new Array();
 
-            int len = args.Length;
-            var res = new JSValue[len];
-            for (int i = 0; i < len; i++)
-                res[i] = args[i].CloneImpl(false);
-
-            return new Array(res);
+            return new Array(args);
         }
 
         [DoNotEnumerate]

--- a/NiL.JS/BaseLibrary/Array.cs
+++ b/NiL.JS/BaseLibrary/Array.cs
@@ -931,7 +931,12 @@ namespace NiL.JS.BaseLibrary
             if (_data == null || _data.Length == 0)
                 return "";
 
-            var sb = new System.Text.StringBuilder();
+            if ((_data.Length - 1) * separator.Length > int.MaxValue)
+                ExceptionHelper.Throw(new RangeError("The array is too big"));
+
+            selfA._data = emptyData;
+
+            var sb = new System.Text.StringBuilder((int)((_data.Length - 1) * separator.Length));
             JSValue t, temp = 0;
 
             for (long i = 0; i < _data.Length; i++)
@@ -965,6 +970,8 @@ namespace NiL.JS.BaseLibrary
                         sb.Append(locale ? t.ToPrimitiveValue_LocaleString_Value() : t.ToPrimitiveValue_String_Value());
                 }
             }
+
+            selfA._data = _data;
 
             return sb.ToString();
         }

--- a/NiL.JS/BaseLibrary/Array.cs
+++ b/NiL.JS/BaseLibrary/Array.cs
@@ -177,7 +177,7 @@ namespace NiL.JS.BaseLibrary
                 }
                 if (!res)
                 {
-                    SetLenght(nlen + 1); // áåñêîíå÷íîé ðåêóðñèè íå ìîæåò áûòü.
+                    SetLenght(nlen + 1);
                     return false;
                 }
             }
@@ -1576,7 +1576,7 @@ namespace NiL.JS.BaseLibrary
                 }
                 return res;
             }
-            else // êòî-òî îòïðàâèë îáúåêò ñ ïîëåì length
+            else
             {
                 long _length = Tools.getLengthOfArraylike(self, false);
                 var pos0 = (long)System.Math.Min(Tools.JSObjectToDouble(args[0]), _length);

--- a/NiL.JS/BaseLibrary/Array.cs
+++ b/NiL.JS/BaseLibrary/Array.cs
@@ -989,6 +989,20 @@ namespace NiL.JS.BaseLibrary
         }
 
         [DoNotEnumerate]
+        public static JSValue of(Arguments args)
+        {
+            if (args == null || args.Length == 0)
+                return new Array();
+
+            int len = args.Length;
+            var res = new JSValue[len];
+            for (int i = 0; i < len; i++)
+                res[i] = args[i].CloneImpl(false);
+
+            return new Array(res);
+        }
+
+        [DoNotEnumerate]
         [InstanceMember]
         [ArgumentsCount(0)]
         public static JSValue pop(JSValue self)

--- a/NiL.JS/BaseLibrary/RegExp.cs
+++ b/NiL.JS/BaseLibrary/RegExp.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Text;
 using System.Text.RegularExpressions;
 using NiL.JS.Core;
 using NiL.JS.Core.Interop;
@@ -113,7 +115,7 @@ namespace NiL.JS.BaseLibrary
                             }
                         default:
                             {
-                                ExceptionHelper.Throw((new SyntaxError("Invalid RegExp flag \"" + flags[i] + '"')));
+                                ExceptionHelper.Throw(new SyntaxError("Invalid RegExp flag \"" + flags[i] + '"'));
                                 break;
                             }
                     }
@@ -137,9 +139,11 @@ namespace NiL.JS.BaseLibrary
                     }
                 }
 
-                // We will need a transpiler to support ES6 Unicode regular expressions.
-                // For now, I settled with Unicode escapes like \u{41} being supported.
-                _regex = new Regex(Tools.Unescape(pattern, false, false, true, _unicode), options);
+                pattern = Tools.Unescape(pattern, false, false, true, _unicode);
+                if (_unicode)
+                    pattern = translateToUnicodePattern(pattern);
+
+                _regex = new Regex(pattern, options);
 
                 _cacheIndex = (_cacheIndex + 1) % _cacheSize;
                 _cache[_cacheIndex].key = label;
@@ -147,9 +151,332 @@ namespace NiL.JS.BaseLibrary
             }
             catch (ArgumentException e)
             {
-                ExceptionHelper.Throw((new SyntaxError(e.Message)));
+                ExceptionHelper.Throw(new SyntaxError(e.Message));
             }
         }
+
+        private static string translateToUnicodePattern(string pattern)
+        {
+            if (pattern == null || pattern == "")
+                return "";
+
+            var s = new StringBuilder(pattern.Length);
+
+            /**
+             * This is what we need to change:
+             * 1.   The dot. It has to be adjusted so that is now also matches all surrogate pairs.
+             * 2.   Character sets have to be adjusted:
+             *      a)  [ (surrogate pair) ] should match the code point and not the high or low part of the surrogate pair.
+             *      b)  [^ set ] should include all Unicode characters (also > \uFFFF) except set.
+             *      c)  [(surrogate pair or UTF-16 char)-(surrogate pair)] should not throw an error.
+             * 3.   Character classes (\D, \S and \W) outside of sets have to be adjusted.
+             * 4.   Surrogate pairs should be surrounded by a non-capturing group to act as one character
+             */
+
+            for (int i = 0; i < pattern.Length; i++)
+            {
+                char c = pattern[i];
+
+                if (c == '.')
+                {
+                    s.Append("(?:[\uD800-\uDBFF][\uDC00-\uDFFF]|.)");
+                }
+                else if (c == '[' && i + 1 < pattern.Length)
+                {
+                    int stop = i + 1;
+                    while (i < pattern.Length && pattern[stop] != ']')
+                    {
+                        if (pattern[stop] == '\\')
+                            stop++;
+                        stop++;
+                    }
+
+                    if (stop >= pattern.Length)
+                    {
+                        s.Append('[');
+                        continue;
+                    }
+
+                    bool inv = pattern[i + 1] == '^';
+                    if (inv)
+                        i++;
+
+                    s.Append(translateCharSet(pattern.Substring(i + 1, stop - i - 1), inv));
+                    i = stop;
+                }
+                else if (c == '\\' && i + 1 < pattern.Length)
+                {
+                    c = pattern[++i];
+                    if (c == 'D' || c == 'S' || c == 'W')
+                        s.Append("(?:[\uD800-\uDBFF][\uDC00-\uDFFF]|\\" + c + ")");
+                    else
+                        s.Append('\\').Append(c);
+                }
+                else if (Tools.IsSurrogatePair(pattern, i))
+                {
+                    s.Append("(?:").Append(c).Append(pattern[++i]).Append(')');
+                }
+                else
+                    s.Append(c);
+            }
+
+            return s.ToString();
+        }
+
+        private struct CharRange
+        {
+            public int start;
+            public int stop; // inclusive
+
+            public CharRange(int start, int stop)
+            {
+                this.start = start;
+                this.stop = stop;
+            }
+
+            public static int MaxValue = 0x10FFFF;
+            public static int MinValue = 0;
+        }
+        private static string translateCharSet(string set, bool inverted)
+        {
+            CharRange[] crs = analyzeCharSet(set); // character ranges
+            if (inverted)
+                crs = invertCharSet(crs);
+
+            if (crs.Length == 0)
+                return @"[]";
+
+            if (crs.Length == 1 && crs[0].start == 0 && crs[0].stop == CharRange.MaxValue)
+                return @"(?:[\uD800-\uDBFF][\uDC00-\uDFFF]|[\s\S])";
+
+            var sC = new List<CharRange>(crs); // single char ranges
+            for (var i = sC.Count - 1; i >= 0; i--)
+            {
+                if (sC[i].start > 0xFFFF)
+                {
+                    sC.RemoveAt(i);
+                    continue;
+                }
+                else if (sC[i].stop > 0xFFFF)
+                    sC[i] = new CharRange(sC[i].start, 0xFFFF);
+                break;
+            }
+
+            var mC = new List<CharRange>(crs.Length - sC.Count + 1); // multi char ranges
+            for (int i = 0; i < crs.Length; i++)
+            {
+                if (crs[i].start > 0xFFFF)
+                    mC.Add(crs[i]);
+                else if (crs[i].stop > 0xFFFF)
+                    mC.Add(new CharRange(0x10000, crs[i].stop));
+            }
+
+
+            var s = new StringBuilder("(?:");
+
+            if (mC.Count > 0)
+            {
+                s.Append("(?:");
+
+                for (int i = 0; i < mC.Count; i++)
+                {
+                    if (i > 0)
+                        s.Append('|');
+
+                    var c = mC[i];
+
+                    if (c.start == c.stop)
+                        s.Append(Tools.CodePointToString(c.start));
+                    else
+                    {
+                        var start = Tools.CodePointToString(c.start);
+                        var stop = Tools.CodePointToString(c.stop);
+
+                        // It will print each character range independent from each other.
+                        // (This might not be the most efficient way)
+
+                        // This assumes c.start <= c.stop
+                        // (which will be true if CharRange is used correctly)
+
+                        if (start[0] == stop[0])
+                            s.Append(start[0]).Append('[').Append(start[1]).Append('-').Append(stop[1]).Append(']');
+                        else
+                        {
+                            int s1 = (start[1] > '\uDC00') ? 1 : 0;
+                            int s2 = (stop[1] < '\uDFFF') ? 1 : 0;
+
+                            if (s1 != 0)
+                                s.Append(start[0]).Append('[').Append(start[1]).Append("-\uDFFF]|");
+                            if (stop[0] - start[0] >= s1 + s2)
+                            {
+                                s.Append('[');
+                                s.Append((char)(start[0] + s1));
+                                s.Append('-');
+                                s.Append((char)(stop[0] - s2));
+                                s.Append(']');
+                                s.Append("[\uDC00-\uDFFF]|");
+                            }
+                            if (s2 != 0)
+                                s.Append(stop[0]).Append("[\uDC00-").Append(stop[1]).Append(']');
+                        }
+                    }
+                }
+
+                s.Append(")");
+            }
+
+            if (sC.Count > 0)
+            {
+                if (mC.Count > 0)
+                    s.Append('|');
+
+                s.Append("[");
+                for (int i = 0; i < sC.Count; i++)
+                {
+                    var c = sC[i];
+                    if (c.start == c.stop)
+                        s.Append("\\u").Append(c.start.ToString("X4"));
+                    else
+                    {
+                        s.Append("\\u").Append(c.start.ToString("X4"));
+                        if (c.stop > c.start + 1)
+                            s.Append('-');
+                        s.Append("\\u").Append(c.stop.ToString("X4"));
+                    }
+                }
+                s.Append("]");
+            }
+
+
+            s.Append(")");
+            return s.ToString();
+        }
+        private static CharRange[] analyzeCharSet(string set)
+        {
+            var r = new List<CharRange>();
+
+            char c;
+            int cI, dI;
+            for (int i = 0; i < set.Length; i++)
+            {
+                c = set[i];
+                cI = Tools.NextCodePoint(set, ref i);
+
+                if (c == '\\' && i + 1 < set.Length)
+                {
+                    c = set[++i];
+
+                    if (c == 'd')
+                    {
+                        r.Add(new CharRange(48, 57));
+                        continue;
+                    }
+                    if (c == 'D')
+                    {
+                        r.Add(new CharRange(0, 47));
+                        r.Add(new CharRange(58, CharRange.MaxValue));
+                        continue;
+                    }
+                    else if (c == 's')
+                    {
+                        r.Add(new CharRange(9, 10));
+                        r.Add(new CharRange(13, 13));
+                        r.Add(new CharRange(32, 32));
+                        continue;
+                    }
+                    else if (c == 'S')
+                    {
+                        r.Add(new CharRange(0, 8));
+                        r.Add(new CharRange(11, 12));
+                        r.Add(new CharRange(14, 31));
+                        r.Add(new CharRange(33, CharRange.MaxValue));
+                        continue;
+                    }
+                    else if (c == 'w')
+                    {
+                        r.Add(new CharRange(48, 57));
+                        r.Add(new CharRange(65, 90));
+                        r.Add(new CharRange(95, 95));
+                        r.Add(new CharRange(97, 122));
+                        continue;
+                    }
+                    else if (c == 'W')
+                    {
+                        r.Add(new CharRange(0, 47));
+                        r.Add(new CharRange(58, 64));
+                        r.Add(new CharRange(91, 94));
+                        r.Add(new CharRange(96, 96));
+                        r.Add(new CharRange(123, CharRange.MaxValue));
+                        continue;
+                    }
+
+                    i--;
+                }
+
+                if (i + 2 < set.Length && set[i + 1] == '-') // -[char]
+                {
+                    i += 2;
+                    dI = Tools.NextCodePoint(set, ref i, true);
+
+                    if (dI < cI)
+                        ExceptionHelper.Throw(new SyntaxError("Range out of order in character class"));
+
+                    r.Add(new CharRange(cI, dI));
+                    continue;
+                }
+
+                r.Add(new CharRange(cI, cI));
+            }
+
+
+            if (r.Count <= 1)
+                return r.ToArray();
+
+            // sort
+
+            r.Sort(new Comparison<CharRange>(new Func<CharRange, CharRange, int>((x, y) => x.start - y.start)));
+
+            // optimize
+
+            var _r = new List<CharRange>();
+
+            CharRange cr = r[0];
+            for (int i = 1; i < r.Count; i++)
+            {
+                if (r[i].stop <= cr.stop)
+                    continue;
+                if (cr.stop >= r[i].start - 1)
+                {
+                    cr.stop = r[i].stop;
+                    continue;
+                }
+
+                _r.Add(cr);
+                cr = r[i];
+            }
+            _r.Add(cr);
+
+            return _r.ToArray();
+        }
+        private static CharRange[] invertCharSet(CharRange[] set)
+        {
+            if (set.Length == 0)
+                return new CharRange[] { new CharRange(0, CharRange.MaxValue) };
+
+            var r = new List<CharRange>();
+
+            if (set[0].start > 0)
+                r.Add(new CharRange(0, set[0].start - 1));
+
+            for (int i = 1; i < set.Length; i++)
+                r.Add(new CharRange(set[i - 1].stop + 1, set[i].start - 1));
+
+            if (set[set.Length - 1].stop < CharRange.MaxValue)
+                r.Add(new CharRange(set[set.Length - 1].stop + 1, CharRange.MaxValue));
+
+            return r.ToArray();
+        }
+
 
         [DoNotEnumerate]
         public RegExp(Arguments args)

--- a/NiL.JS/BaseLibrary/RegExp.cs
+++ b/NiL.JS/BaseLibrary/RegExp.cs
@@ -58,10 +58,10 @@ namespace NiL.JS.BaseLibrary
             }
             var pattern = ptrn._valueType > JSValueType.Undefined ? ptrn.ToString() : "";
             var flags = args.GetProperty("length")._iValue > 1 && args[1]._valueType > JSValueType.Undefined ? args[1].ToString() : "";
-            makeRegex(pattern, flags, false);
+            makeRegex(pattern, flags);
         }
 
-        private void makeRegex(string pattern, string flags, bool unescapeFlags)
+        private void makeRegex(string pattern, string flags)
         {
             pattern = pattern ?? "null";
             flags = flags ?? "null";
@@ -72,8 +72,6 @@ namespace NiL.JS.BaseLibrary
             {
                 var options = RegexOptions.ECMAScript | RegexOptions.CultureInvariant;
 
-                if (unescapeFlags)
-                    flags = Tools.Unescape(flags, false, true, false, true);
                 for (int i = 0; i < flags.Length; i++)
                 {
                     switch (flags[i])
@@ -438,7 +436,7 @@ namespace NiL.JS.BaseLibrary
 
             // optimize
 
-            var _r = new List<CharRange>();
+            var rNew = new List<CharRange>();
 
             CharRange cr = r[0];
             for (int i = 1; i < r.Count; i++)
@@ -451,12 +449,12 @@ namespace NiL.JS.BaseLibrary
                     continue;
                 }
 
-                _r.Add(cr);
+                rNew.Add(cr);
                 cr = r[i];
             }
-            _r.Add(cr);
+            rNew.Add(cr);
 
-            return _r.ToArray();
+            return rNew.ToArray();
         }
         private static CharRange[] invertCharSet(CharRange[] set)
         {
@@ -486,15 +484,8 @@ namespace NiL.JS.BaseLibrary
 
         [DoNotEnumerate]
         public RegExp(string pattern, string flags)
-            : this(pattern, flags, false)
         {
-        }
-
-        [DoNotEnumerate]
-        [Hidden]
-        public RegExp(string pattern, string flags, bool unescapeFlags)
-        {
-            makeRegex(pattern, flags, unescapeFlags);
+            makeRegex(pattern, flags);
         }
 
         internal bool _global;

--- a/NiL.JS/BaseLibrary/RegExp.cs
+++ b/NiL.JS/BaseLibrary/RegExp.cs
@@ -79,35 +79,35 @@ namespace NiL.JS.BaseLibrary
                         case 'i':
                             {
                                 if ((options & RegexOptions.IgnoreCase) != 0)
-                                    ExceptionHelper.Throw((new SyntaxError("Try to double use RegExp flag \"" + flags[i] + '"')));
+                                    ExceptionHelper.Throw(new SyntaxError("Try to double use RegExp flag \"" + flags[i] + '"'));
                                 options |= RegexOptions.IgnoreCase;
                                 break;
                             }
                         case 'm':
                             {
                                 if ((options & RegexOptions.Multiline) != 0)
-                                    ExceptionHelper.Throw((new SyntaxError("Try to double use RegExp flag \"" + flags[i] + '"')));
+                                    ExceptionHelper.Throw(new SyntaxError("Try to double use RegExp flag \"" + flags[i] + '"'));
                                 options |= RegexOptions.Multiline;
                                 break;
                             }
                         case 'g':
                             {
                                 if (_global)
-                                    ExceptionHelper.Throw((new SyntaxError("Try to double use RegExp flag \"" + flags[i] + '"')));
+                                    ExceptionHelper.Throw(new SyntaxError("Try to double use RegExp flag \"" + flags[i] + '"'));
                                 _global = true;
                                 break;
                             }
                         case 'u':
                             {
                                 if (_unicode)
-                                    ExceptionHelper.Throw((new SyntaxError("Try to double use RegExp flag \"" + flags[i] + '"')));
+                                    ExceptionHelper.Throw(new SyntaxError("Try to double use RegExp flag \"" + flags[i] + '"'));
                                 _unicode = true;
                                 break;
                             }
                         case 'y':
                             {
                                 if (_sticky)
-                                    ExceptionHelper.Throw((new SyntaxError("Try to double use RegExp flag \"" + flags[i] + '"')));
+                                    ExceptionHelper.Throw(new SyntaxError("Try to double use RegExp flag \"" + flags[i] + '"'));
                                 _sticky = true;
                                 break;
                             }
@@ -121,8 +121,8 @@ namespace NiL.JS.BaseLibrary
                 _source = pattern;
 
                 string label = _source + "/"
-                + ((options & System.Text.RegularExpressions.RegexOptions.IgnoreCase) != 0 ? "i" : "")
-                + ((options & System.Text.RegularExpressions.RegexOptions.Multiline) != 0 ? "m" : "")
+                + ((options & RegexOptions.IgnoreCase) != 0 ? "i" : "")
+                + ((options & RegexOptions.Multiline) != 0 ? "m" : "")
                 + (_unicode ? "u" : "");
                 if (_cacheIndex >= 0)
                 {
@@ -194,7 +194,7 @@ namespace NiL.JS.BaseLibrary
         {
             get
             {
-                return (_regex.Options & System.Text.RegularExpressions.RegexOptions.IgnoreCase) != 0;
+                return (_regex.Options & RegexOptions.IgnoreCase) != 0;
             }
         }
 
@@ -207,7 +207,7 @@ namespace NiL.JS.BaseLibrary
         {
             get
             {
-                return (_regex.Options & System.Text.RegularExpressions.RegexOptions.Multiline) != 0;
+                return (_regex.Options & RegexOptions.Multiline) != 0;
             }
         }
 
@@ -382,8 +382,8 @@ namespace NiL.JS.BaseLibrary
         {
             return "/" + _source + "/"
                 + (_global ? "g" : "")
-                + ((_regex.Options & System.Text.RegularExpressions.RegexOptions.IgnoreCase) != 0 ? "i" : "")
-                + ((_regex.Options & System.Text.RegularExpressions.RegexOptions.Multiline) != 0 ? "m" : "")
+                + ((_regex.Options & RegexOptions.IgnoreCase) != 0 ? "i" : "")
+                + ((_regex.Options & RegexOptions.Multiline) != 0 ? "m" : "")
                 + (_unicode ? "u" : "")
                 + (_sticky ? "y" : "");
         }

--- a/NiL.JS/BaseLibrary/RegExp.cs
+++ b/NiL.JS/BaseLibrary/RegExp.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.RegularExpressions;
 using NiL.JS.Core;
 using NiL.JS.Core.Interop;
@@ -10,16 +10,33 @@ namespace NiL.JS.BaseLibrary
 #endif
     public sealed class RegExp : CustomType
     {
+        private struct RegExpCacheItem
+        {
+            public string key;
+            public Regex re;
+            public RegExpCacheItem(string key, Regex re)
+            {
+                this.key = key;
+                this.re = re;
+            }
+        }
+        private static RegExpCacheItem[] _cache = new RegExpCacheItem[_cacheSize];
+        private static int _cacheIndex = -1;
+        private const int _cacheSize = 16;
+
+
         private string _source;
-        private JSValue lIndex;
-        internal Regex _Regex;
+        private JSValue _lastIndex;
+        internal Regex _regex;
 
         [DoNotEnumerate]
         public RegExp()
         {
             _source = "";
             _global = false;
-            _Regex = new Regex("");
+            _sticky = false;
+            _unicode = false;
+            _regex = new Regex("");
         }
 
         private void makeRegex(Arguments args)
@@ -30,38 +47,34 @@ namespace NiL.JS.BaseLibrary
                 if (args.GetProperty("length")._iValue > 1 && args[1]._valueType > JSValueType.Undefined)
                     ExceptionHelper.Throw(new TypeError("Cannot supply flags when constructing one RegExp from another"));
                 _oValue = ptrn._oValue;
-                _Regex = (ptrn.Value as RegExp)._Regex;
-                _global = (ptrn.Value as RegExp).global;
+                _regex = (ptrn.Value as RegExp)._regex;
+                _global = (ptrn.Value as RegExp)._global;
+                _sticky = (ptrn.Value as RegExp)._sticky;
+                _unicode = (ptrn.Value as RegExp)._unicode;
                 _source = (ptrn.Value as RegExp)._source;
                 return;
             }
             var pattern = ptrn._valueType > JSValueType.Undefined ? ptrn.ToString() : "";
             var flags = args.GetProperty("length")._iValue > 1 && args[1]._valueType > JSValueType.Undefined ? args[1].ToString() : "";
-            makeRegex(pattern, flags);
+            makeRegex(pattern, flags, false);
         }
 
-        private void makeRegex(string pattern, string flags)
+        private void makeRegex(string pattern, string flags, bool unescapeFlags)
         {
             pattern = pattern ?? "null";
-            flags = flags ?? "~";
+            flags = flags ?? "null";
             _global = false;
+            _sticky = false;
+            _unicode = false;
             try
             {
                 var options = RegexOptions.ECMAScript | RegexOptions.CultureInvariant;
+
+                if (unescapeFlags)
+                    flags = Tools.Unescape(flags, false, true, false, true);
                 for (int i = 0; i < flags.Length; i++)
                 {
-                    char c = flags[i];
-                    if (c == '\\')
-                    {
-                        int len = 1;
-                        if (flags[i + 1] == 'u')
-                            len = 5;
-                        else if (flags[i + 1] == 'x')
-                            len = 3;
-                        c = Tools.Unescape(flags.Substring(i, len + 1), false)[0];
-                        i += len;
-                    }
-                    switch (c)
+                    switch (flags[i])
                     {
                         case 'i':
                             {
@@ -84,6 +97,20 @@ namespace NiL.JS.BaseLibrary
                                 _global = true;
                                 break;
                             }
+                        case 'u':
+                            {
+                                if (_unicode)
+                                    ExceptionHelper.Throw((new SyntaxError("Try to double use RegExp flag \"" + flags[i] + '"')));
+                                _unicode = true;
+                                break;
+                            }
+                        case 'y':
+                            {
+                                if (_sticky)
+                                    ExceptionHelper.Throw((new SyntaxError("Try to double use RegExp flag \"" + flags[i] + '"')));
+                                _sticky = true;
+                                break;
+                            }
                         default:
                             {
                                 ExceptionHelper.Throw((new SyntaxError("Invalid RegExp flag \"" + flags[i] + '"')));
@@ -92,7 +119,31 @@ namespace NiL.JS.BaseLibrary
                     }
                 }
                 _source = pattern;
-                _Regex = new Regex(Tools.Unescape(pattern, false, false, true), options);
+
+                string label = _source + "/"
+                + ((options & System.Text.RegularExpressions.RegexOptions.IgnoreCase) != 0 ? "i" : "")
+                + ((options & System.Text.RegularExpressions.RegexOptions.Multiline) != 0 ? "m" : "")
+                + (_unicode ? "u" : "");
+                if (_cacheIndex >= 0)
+                {
+                    int _cacheSizeMinusOne = _cacheSize - 1;
+                    for (var i = _cacheSize + _cacheIndex; i > _cacheIndex; i--)
+                    {
+                        if (_cache[i & _cacheSizeMinusOne].key == label)
+                        {
+                            _regex = _cache[i & _cacheSizeMinusOne].re;
+                            return;
+                        }
+                    }
+                }
+
+                // We will need a transpiler to support ES6 Unicode regular expressions.
+                // For now, I settled with Unicode escapes like \u{41} being supported.
+                _regex = new Regex(Tools.Unescape(pattern, false, false, true, _unicode), options);
+
+                _cacheIndex = (_cacheIndex + 1) % _cacheSize;
+                _cache[_cacheIndex].key = label;
+                _cache[_cacheIndex].re = _regex;
             }
             catch (ArgumentException e)
             {
@@ -108,34 +159,15 @@ namespace NiL.JS.BaseLibrary
 
         [DoNotEnumerate]
         public RegExp(string pattern, string flags)
+            : this(pattern, flags, false)
         {
-            makeRegex(pattern, flags);
         }
 
-        [Field]
-        [ReadOnly]
-        [DoNotDelete]
         [DoNotEnumerate]
-        [NotConfigurable]
-        public Boolean ignoreCase
+        [Hidden]
+        public RegExp(string pattern, string flags, bool unescapeFlags)
         {
-            get
-            {
-                return (_Regex.Options & System.Text.RegularExpressions.RegexOptions.IgnoreCase) != 0;
-            }
-        }
-
-        [Field]
-        [ReadOnly]
-        [DoNotDelete]
-        [DoNotEnumerate]
-        [NotConfigurable]
-        public Boolean multiline
-        {
-            get
-            {
-                return (_Regex.Options & System.Text.RegularExpressions.RegexOptions.Multiline) != 0;
-            }
+            makeRegex(pattern, flags, unescapeFlags);
         }
 
         internal bool _global;
@@ -150,6 +182,62 @@ namespace NiL.JS.BaseLibrary
             get
             {
                 return _global;
+            }
+        }
+
+        [Field]
+        [ReadOnly]
+        [DoNotDelete]
+        [DoNotEnumerate]
+        [NotConfigurable]
+        public Boolean ignoreCase
+        {
+            get
+            {
+                return (_regex.Options & System.Text.RegularExpressions.RegexOptions.IgnoreCase) != 0;
+            }
+        }
+
+        [Field]
+        [ReadOnly]
+        [DoNotDelete]
+        [DoNotEnumerate]
+        [NotConfigurable]
+        public Boolean multiline
+        {
+            get
+            {
+                return (_regex.Options & System.Text.RegularExpressions.RegexOptions.Multiline) != 0;
+            }
+        }
+
+        internal bool _sticky;
+        [Field]
+        [ReadOnly]
+        [DoNotDelete]
+        [DoNotEnumerate]
+        [NotConfigurable]
+        public Boolean sticky
+        {
+            [Hidden]
+            get
+            {
+                return _sticky;
+            }
+        }
+
+        internal bool _unicode;
+        [Field]
+        [ReadOnly]
+        [DoNotDelete]
+        [DoNotEnumerate]
+        [NotConfigurable]
+        public Boolean unicode
+        {
+            [Hidden]
+            get
+            {
+                return _unicode;
             }
         }
 
@@ -174,11 +262,11 @@ namespace NiL.JS.BaseLibrary
         {
             get
             {
-                return lIndex ?? (lIndex = 0);
+                return _lastIndex ?? (_lastIndex = 0);
             }
             set
             {
-                lIndex = (value ?? JSValue.undefined).CloneImpl(false);
+                _lastIndex = (value ?? JSValue.undefined).CloneImpl(false);
             }
         }
 
@@ -193,61 +281,91 @@ namespace NiL.JS.BaseLibrary
         public JSValue exec(JSValue arg)
         {
             string input = (arg ?? "null").ToString();
-            lIndex = Tools.JSObjectToNumber(lastIndex);
-            if ((lIndex._attributes & JSValueAttributesInternal.SystemObject) != 0)
-                lIndex = lIndex.CloneImpl(false);
-            if (lIndex._valueType == JSValueType.Double)
+
+            if (!_global && !_sticky)
             {
-                lIndex._valueType = JSValueType.Integer;
-                lIndex._iValue = (int)lIndex._dValue;
+                // non-global and/or non-sticky matching doesn't use lastIndex
+
+                var m = _regex.Match(input);
+                if (!m.Success)
+                    return JSValue.@null;
+
+                var res = new Array(m.Groups.Count);
+                for (int i = 0; i < m.Groups.Count; i++)
+                    res._data[i] = m.Groups[i].Success ? (JSValue)m.Groups[i].Value : null;
+
+                res.DefineProperty("index").Assign(m.Index);
+                res.DefineProperty("input").Assign(input);
+
+                return res;
             }
-            if (lIndex._iValue < 0)
-                lIndex._iValue = 0;
-            if (lIndex._iValue >= input.Length && input.Length > 0)
+            else
             {
-                lIndex._iValue = 0;
-                return JSValue.@null;
+                _lastIndex = Tools.JSObjectToNumber(_lastIndex);
+                if ((_lastIndex._attributes & JSValueAttributesInternal.SystemObject) != 0)
+                    _lastIndex = _lastIndex.CloneImpl(false);
+                if (_lastIndex._valueType == JSValueType.Double)
+                {
+                    _lastIndex._valueType = JSValueType.Integer;
+                    _lastIndex._iValue = (int)_lastIndex._dValue;
+                }
+
+                int li = (_lastIndex._iValue < 0) ? 0 : _lastIndex._iValue;
+                _lastIndex._iValue = 0;
+
+                if (li >= input.Length && input.Length > 0)
+                    return JSValue.@null;
+
+                var m = _regex.Match(input, li);
+                if (!m.Success || (_sticky && m.Index != li))
+                    return JSValue.@null;
+
+                var res = new Array(m.Groups.Count);
+                for (int i = 0; i < m.Groups.Count; i++)
+                    res._data[i] = m.Groups[i].Success ? (JSValue)m.Groups[i].Value : null;
+
+                _lastIndex._iValue = m.Index + m.Length;
+
+                res.DefineProperty("index").Assign(m.Index);
+                res.DefineProperty("input").Assign(input);
+
+                return res;
             }
-            var m = _Regex.Match(input, lIndex._iValue);
-            if (!m.Success)
-            {
-                lIndex._iValue = 0;
-                return JSValue.@null;
-            }
-            var res = new Array(m.Groups.Count);
-            for (int i = 0; i < m.Groups.Count; i++)
-                res._data[i] = m.Groups[i].Success ? (JSValue)m.Groups[i].Value : null;
-            if (_global)
-                lIndex._iValue = m.Index + m.Length;
-            res.DefineProperty("index").Assign(m.Index);
-            res.DefineProperty("input").Assign(input);
-            return res;
         }
 
         [DoNotEnumerate]
         public JSValue test(JSValue arg)
         {
+            // definition: exec(arg) != null
+
             string input = (arg ?? "null").ToString();
-            lIndex = Tools.JSObjectToNumber(lIndex);
-            if (lIndex._valueType == JSValueType.Double)
+
+            if (!_global && !_sticky)
+                return _regex.IsMatch(input);
+
+
+            _lastIndex = Tools.JSObjectToNumber(_lastIndex);
+            if ((_lastIndex._attributes & JSValueAttributesInternal.SystemObject) != 0)
+                _lastIndex = _lastIndex.CloneImpl(false);
+            if (_lastIndex._valueType == JSValueType.Double)
             {
-                lIndex._valueType = JSValueType.Integer;
-                lIndex._iValue = (int)lIndex._dValue;
+                _lastIndex._valueType = JSValueType.Integer;
+                _lastIndex._iValue = (int)_lastIndex._dValue;
             }
-            if (lIndex._iValue >= input.Length || lIndex._iValue < 0)
-            {
-                lIndex._iValue = 0;
+
+            int li = (_lastIndex._iValue < 0) ? 0 : _lastIndex._iValue;
+            _lastIndex._iValue = 0;
+
+            if (li >= input.Length && input.Length > 0)
                 return false;
-            }
-            var m = _Regex.Match(input, lIndex._iValue);
-            if (!m.Success)
-            {
-                lIndex._iValue = 0;
+
+            var m = _regex.Match(input, li);
+            if (!m.Success || (_sticky && m.Index != li))
                 return false;
-            }
-            if (_global)
-                lastIndex._iValue = m.Index + m.Length;
-            return m.Success;
+
+            _lastIndex._iValue = m.Index + m.Length;
+
+            return true;
         }
 
 #if !WRC
@@ -263,9 +381,11 @@ namespace NiL.JS.BaseLibrary
         public override string ToString()
         {
             return "/" + _source + "/"
-                + ((_Regex.Options & System.Text.RegularExpressions.RegexOptions.IgnoreCase) != 0 ? "i" : "")
-                + ((_Regex.Options & System.Text.RegularExpressions.RegexOptions.Multiline) != 0 ? "m" : "")
-                + (_global ? "g" : "");
+                + (_global ? "g" : "")
+                + ((_regex.Options & System.Text.RegularExpressions.RegexOptions.IgnoreCase) != 0 ? "i" : "")
+                + ((_regex.Options & System.Text.RegularExpressions.RegexOptions.Multiline) != 0 ? "m" : "")
+                + (_unicode ? "u" : "")
+                + (_sticky ? "y" : "");
         }
     }
 }

--- a/NiL.JS/BaseLibrary/String.cs
+++ b/NiL.JS/BaseLibrary/String.cs
@@ -799,42 +799,12 @@ namespace NiL.JS.BaseLibrary
             if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
                 ExceptionHelper.Throw(new TypeError("String.prototype.trim called on null or undefined"));
 
-            try
-            {
-                var sb = new StringBuilder(self.ToString());
-                int initialLength = sb.Length;
-                int index = 0;
-                for (; index < sb.Length && System.Array.IndexOf(Tools.TrimChars, sb[index]) != -1; index++)
-                    ;
-                if (index > 0)
-                    sb.Remove(0, index);
-                index = sb.Length - 1;
-                while (index >= 0 && System.Array.IndexOf(Tools.TrimChars, sb[index]) != -1)
-                    index--;
-                index++;
-                if (index < sb.Length)
-                    sb.Remove(index, sb.Length - index);
-                if (sb.Length != initialLength)
-                {
-                    index = 0;
-                    for (;;)
-                    {
-                        while (index < sb.Length && sb[index] != '\n' && sb[index] != '\r')
-                            index++;
-                        if (index >= sb.Length)
-                            break;
-                        var startindex = index;
-                        for (; index < sb.Length && System.Array.IndexOf(Tools.TrimChars, sb[index]) != -1; index++)
-                            ;
-                        sb.Remove(startindex, index - startindex);
-                    }
-                }
-                return sb.ToString();
-            }
-            catch
-            {
-                throw;
-            }
+            var selfStr = self.ToString();
+
+            if (selfStr == "")
+                return selfStr;
+
+            return selfStr.Trim(Tools.TrimChars);
         }
 
         [DoNotEnumerate]

--- a/NiL.JS/BaseLibrary/String.cs
+++ b/NiL.JS/BaseLibrary/String.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Text.RegularExpressions;
 using NiL.JS.Core;
 using NiL.JS.Core.Interop;
-using NiL.JS.Extensions;
 
 namespace NiL.JS.BaseLibrary
 {
@@ -14,32 +12,33 @@ namespace NiL.JS.BaseLibrary
     public sealed class String : JSObject
     {
         [DoNotEnumerate]
-        public static JSValue fromCharCode(Arguments code)
+        public static JSValue fromCharCode(Arguments args)
         {
-            int chc = 0;
-            if (code == null || code.Length == 0)
+            if (args == null || args.Length == 0)
                 return new String();
+
+            int chc = 0;
             string res = "";
-            for (int i = 0; i < code.Length; i++)
+            for (int i = 0; i < args.Length; i++)
             {
-                chc = Tools.JSObjectToInt32(code[i]);
+                chc = Tools.JSObjectToInt32(args[i]);
                 res += ((char)chc).ToString();
             }
             return res;
         }
 
         [DoNotEnumerate]
-        public static JSValue fromCodePoint(Arguments code)
+        public static JSValue fromCodePoint(Arguments args)
         {
-            if (code == null || code.Length == 0)
+            if (args == null || args.Length == 0)
                 return new String();
 
             JSValue n;
             uint ucs = 0;
             string res = "";
-            for (int i = 0; i < code.Length; i++)
+            for (int i = 0; i < args.Length; i++)
             {
-                n = Tools.JSObjectToNumber(code[i]);
+                n = Tools.JSObjectToNumber(args[i]);
                 if (n._valueType == JSValueType.Integer)
                 {
                     if (n._iValue < 0 || n._iValue > 0x10FFFF)
@@ -104,40 +103,49 @@ namespace NiL.JS.BaseLibrary
         [DoNotEnumerate]
         [InstanceMember]
         [ArgumentsCount(1)]
-        public static String charAt(JSValue self, Arguments pos)
+        public static String charAt(JSValue self, Arguments args)
         {
-            var strValue = self.ToString();
-            int p = Tools.JSObjectToInt32(pos[0], true);
-            if ((p < 0) || (p >= strValue.Length))
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.charAt called on null or undefined"));
+
+            var selfStr = self.ToString();
+
+            int p = Tools.JSObjectToInt32(args[0], true);
+            if (p < 0 || p >= selfStr.Length)
                 return "";
-            return strValue[p].ToString();//Tools.charStrings[strValue[p]];
+
+            return selfStr[p].ToString();
         }
 
         [DoNotEnumerate]
         [InstanceMember]
         [ArgumentsCount(1)]
-        public static JSValue charCodeAt(JSValue self, Arguments pos)
+        public static JSValue charCodeAt(JSValue self, Arguments args)
         {
-            int p = Tools.JSObjectToInt32(pos[0], true);
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.charCodeAt called on null or undefined"));
+
             var selfStr = self.ToString();
-            if ((p < 0) || (p >= selfStr.Length))
+
+            int p = Tools.JSObjectToInt32(args[0], true);
+            if (p < 0 || p >= selfStr.Length)
                 return Number.NaN;
-            var res = new JSValue()
-            {
-                _valueType = JSValueType.Integer,
-                _iValue = selfStr[p],
-            };
-            return res;
+
+            return new Number((int)selfStr[p]);
         }
 
         [DoNotEnumerate]
         [InstanceMember]
         [ArgumentsCount(1)]
-        public static JSValue codePointAt(JSValue self, Arguments pos)
+        public static JSValue codePointAt(JSValue self, Arguments args)
         {
-            int p = Tools.JSObjectToInt32(pos[0], true);
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.codePointAt called on null or undefined"));
+
             var selfStr = self.ToString();
-            if ((p < 0) || (p >= selfStr.Length))
+
+            int p = Tools.JSObjectToInt32(args[0], true);
+            if (p < 0 || p >= selfStr.Length)
                 return JSValue.undefined;
 
             // look here in section 3.7 Surrogates for more information.
@@ -152,12 +160,7 @@ namespace NiL.JS.BaseLibrary
                     code = (code - 0xD800) * 0x400 + (low - 0xDC00) + 0x10000;
             }
 
-            var res = new JSValue()
-            {
-                _valueType = JSValueType.Integer,
-                _iValue = code,
-            };
-            return res;
+            return code;
         }
 
         [DoNotEnumerate]
@@ -165,17 +168,24 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(1)]
         public static JSValue concat(JSValue self, Arguments args)
         {
-            if (args.length == 0)
-                return self.ToString();
-            if (args.length == 1)
-                return string.Concat(self.ToString(), args[0].ToString());
-            if (args.length == 2)
-                return string.Concat(self.ToString(), args[0].ToString(), args[1].ToString());
-            if (args.length == 3)
-                return string.Concat(self.ToString(), args[0].ToString(), args[1].ToString(), args[2].ToString());
-            if (args.length == 4)
-                return string.Concat(self.ToString(), args[0].ToString(), args[1].ToString(), args[2].ToString(), args[3].ToString());
-            var res = new StringBuilder().Append(self);
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.concat called on null or undefined"));
+
+            var selfStr = self.ToString();
+
+            if (args == null || args.Length == 0)
+                return selfStr;
+
+            if (args.Length == 1)
+                return string.Concat(selfStr, args[0].ToString());
+            if (args.Length == 2)
+                return string.Concat(selfStr, args[0].ToString(), args[1].ToString());
+            if (args.Length == 3)
+                return string.Concat(selfStr, args[0].ToString(), args[1].ToString(), args[2].ToString());
+            if (args.Length == 4)
+                return string.Concat(selfStr, args[0].ToString(), args[1].ToString(), args[2].ToString(), args[3].ToString());
+
+            var res = new StringBuilder().Append(selfStr);
             for (var i = 0; i < args.Length; i++)
                 res.Append(args[i]);
             return res.ToString();
@@ -186,10 +196,14 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(1)]
         public static JSValue endsWith(JSValue self, Arguments args)
         {
-            var selfAsString = (self ?? undefinedString).ToString();
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.endsWith called on null or undefined"));
+
+            var selfStr = self.ToString();
+
             var value = (args?[0] ?? undefinedString).ToString();
 
-            return selfAsString.EndsWith(value) ? Boolean.True : Boolean.False;
+            return selfStr.EndsWith(value, StringComparison.Ordinal) ? Boolean.True : Boolean.False;
         }
 
 
@@ -198,10 +212,14 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(1)]
         public static JSValue includes(JSValue self, Arguments args)
         {
-            var selfAsString = (self ?? undefinedString).ToString();
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.includes called on null or undefined"));
+
+            var selfStr = self.ToString();
+
             var value = (args?[0] ?? undefinedString).ToString();
 
-            return selfAsString.IndexOf(value) != -1 ? Boolean.True : Boolean.False;
+            return selfStr.IndexOf(value, StringComparison.Ordinal) != -1 ? Boolean.True : Boolean.False;
         }
 
         [DoNotEnumerate]
@@ -209,25 +227,29 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(1)]
         public static JSValue indexOf(JSValue self, Arguments args)
         {
-            if (args.Length == 0)
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.indexOf called on null or undefined"));
+
+            var selfStr = self.ToString();
+
+            if (args == null || args.Length == 0)
                 return -1;
 
-            var strValue = self.ToString();
             string fstr = args[0].ToString();
 
             var pos = 0;
-            if (args.length > 1)
+            if (args.Length > 1)
             {
                 pos = Tools.JSObjectToInt32(args[1], 0, 0, true);
 
                 if (pos < 0)
                     pos = 0;
 
-                if (pos > strValue.Length)
-                    pos = strValue.Length - 1;
+                if (pos > selfStr.Length)
+                    pos = selfStr.Length - 1;
             }
 
-            return strValue.IndexOf(fstr, pos, StringComparison.Ordinal);
+            return selfStr.IndexOf(fstr, pos, StringComparison.Ordinal);
         }
 
         [DoNotEnumerate]
@@ -235,14 +257,18 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(1)]
         public static JSValue lastIndexOf(JSValue self, Arguments args)
         {
-            if (args.Length == 0)
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.lastIndexOf called on null or undefined"));
+
+            var selfStr = self.ToString();
+
+            if (args == null || args.Length == 0)
                 return -1;
 
-            var strValue = self.ToString();
             string fstr = args[0].ToString();
 
-            var pos = strValue.Length;
-            if (args.length > 1)
+            var pos = selfStr.Length;
+            if (args.Length > 1)
             {
                 pos = Tools.JSObjectToInt32(args[1], pos, pos, true);
 
@@ -251,11 +277,11 @@ namespace NiL.JS.BaseLibrary
 
                 pos += fstr.Length;
 
-                if (pos > strValue.Length)
-                    pos = strValue.Length;
+                if (pos > selfStr.Length)
+                    pos = selfStr.Length;
             }
 
-            return strValue.LastIndexOf(fstr, pos, StringComparison.Ordinal);
+            return selfStr.LastIndexOf(fstr, pos, StringComparison.Ordinal);
         }
 
         [DoNotEnumerate]
@@ -263,9 +289,16 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(1)]
         public static JSValue localeCompare(JSValue self, Arguments args)
         {
-            string str0 = self.ToString();
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.localeCompare called on null or undefined"));
+
+            var selfStr = self.ToString();
+
+            if (args == null || args.Length == 0)
+                return -1;
+
             string str1 = args[0].ToString();
-            return string.CompareOrdinal(str0, str1);
+            return string.Compare(selfStr, str1, StringComparison.InvariantCulture);
         }
 
         [DoNotEnumerate]
@@ -273,7 +306,7 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(1)]
         public static JSValue match(JSValue self, Arguments args)
         {
-            if (self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
                 ExceptionHelper.Throw(new TypeError("String.prototype.match called on null or undefined"));
 
             var a0 = args[0];
@@ -329,43 +362,32 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(1)]
         public static JSValue normalize(JSValue self, Arguments args)
         {
-            var selfStr = (self ?? undefinedString).ToString();
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.normalize called on null or undefined"));
 
-            var form = "NFC";
-            if (args != null && args.Length > 0)
-            {
-                var a0 = args[0];
-                if (a0 != null && a0._valueType > JSValueType.Undefined)
-                    form = a0.ToString();
-            }
+            var selfStr = self.ToString();
 
-            switch (form)
-            {
-                case "NFC":
-                    {
-                        selfStr = selfStr.Normalize(NormalizationForm.FormC);
-                        break;
-                    }
-                case "NFD":
-                    {
-                        selfStr = selfStr.Normalize(NormalizationForm.FormD);
-                        break;
-                    }
-                case "NFKC":
-                    {
-                        selfStr = selfStr.Normalize(NormalizationForm.FormKC);
-                        break;
-                    }
-                case "NFKD":
-                    {
-                        selfStr = selfStr.Normalize(NormalizationForm.FormKD);
-                        break;
-                    }
-                default:
-                    ExceptionHelper.Throw(new RangeError("The normalization form should be one of NFC, NFD, NFKC, NFKD"));
-                    break;
-            }
-            return selfStr;
+            if (args == null || args.Length == 0)
+                return selfStr.Normalize(NormalizationForm.FormC);
+
+            string form = "NFC";
+            var a0 = args[0];
+            if (a0 != null && a0._valueType > JSValueType.Undefined)
+                form = a0.ToString();
+
+            NormalizationForm nf = NormalizationForm.FormC;
+            if (form == "NFC")
+                nf = NormalizationForm.FormC;
+            else if (form == "NFD")
+                nf = NormalizationForm.FormD;
+            else if (form == "NFKC")
+                nf = NormalizationForm.FormKC;
+            else if (form == "NFKD")
+                nf = NormalizationForm.FormKD;
+            else
+                ExceptionHelper.Throw(new RangeError("The normalization form should be one of NFC, NFD, NFKC, NFKD"));
+
+            return selfStr.Normalize(nf);
         }
 
         [DoNotEnumerate]
@@ -373,7 +395,15 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(1)]
         public static JSValue repeat(JSValue self, Arguments args)
         {
-            var selfStr = (self ?? undefinedString).ToString();
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.repeat called on null or undefined"));
+
+            var selfStr = self.ToString();
+
+            if (args == null || args.Length == 0)
+                return "";
+            if (selfStr.Length == 0)
+                return "";
 
             double count = 0;
             if (args.Length > 0)
@@ -391,8 +421,6 @@ namespace NiL.JS.BaseLibrary
                 return "";
             if (c == 1)
                 return selfStr;
-            if (selfStr.Length == 0)
-                return "";
 
             var s = new StringBuilder(selfStr.Length * c);
             for (int i = 0; i < c; i++)
@@ -407,16 +435,19 @@ namespace NiL.JS.BaseLibrary
         [AllowNullArguments]
         public static JSValue replace(JSValue self, Arguments args)
         {
-            if (args == null || args.length == 0)
-                return self;
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.replace called on null or undefined"));
+
+            var selfStr = self.ToString();
+
+            if (args == null || args.Length == 0)
+                return selfStr;
 
             var a0 = args[0];
             var regex = a0?.Value as RegExp;
 
             var a1 = args[1];
             var f = a1?.Value as Function;
-
-            var selfStr = self.ToString();
 
             if (regex != null)
             {
@@ -459,12 +490,11 @@ namespace NiL.JS.BaseLibrary
                 string pattern = (a0 ?? "").ToString();
                 if (f != null)
                 {
-                    int index = selfStr.IndexOf(pattern);
+                    int index = selfStr.IndexOf(pattern, StringComparison.Ordinal);
                     if (index == -1)
                         return selfStr;
 
-                    var fArgs = new Arguments();
-                    fArgs.length = 3;
+                    var fArgs = new Arguments() { length = 3 };
                     fArgs[0] = pattern;
                     fArgs[1] = index;
                     fArgs[2] = self;
@@ -477,7 +507,7 @@ namespace NiL.JS.BaseLibrary
                     if (pattern.Length == 0)
                         return replacement + selfStr;
 
-                    var index = selfStr.IndexOf(pattern);
+                    var index = selfStr.IndexOf(pattern, StringComparison.Ordinal);
                     if (index == -1)
                         return selfStr;
 
@@ -491,19 +521,21 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(1)]
         public static JSValue search(JSValue self, Arguments args)
         {
-            if (self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
-                ExceptionHelper.Throw(new TypeError("String.prototype.match called on null or undefined"));
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.search called on null or undefined"));
 
-            if (args.length == 0)
+            string selfStr = self.ToString();
+
+            if (args == null || args.Length == 0)
                 return 0;
 
             var a0 = args[0];
             var regex = a0.Value as RegExp;
 
             if (regex == null)
-                return self.ToString().IndexOf(a0.ToString());
+                return selfStr.IndexOf(a0.ToString(), StringComparison.Ordinal);
 
-            var match = regex._regex.Match(self.ToString());
+            var match = regex._regex.Match(selfStr);
             if (!match.Success)
                 return -1;
 
@@ -518,86 +550,28 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(2)]
         public static JSValue slice(JSValue self, Arguments args)
         {
-            string selfString = self.ToPrimitiveValue_Value_String().ToString();
-            if (args.Length == 0)
-                return selfString;
-            int pos0 = 0;
-            switch (args[0]._valueType)
-            {
-                case JSValueType.Integer:
-                case JSValueType.Boolean:
-                    {
-                        pos0 = args[0]._iValue;
-                        break;
-                    }
-                case JSValueType.Double:
-                    {
-                        if (double.IsNaN(args[0]._dValue) || double.IsNegativeInfinity(args[0]._dValue))
-                            pos0 = 0;
-                        else if (double.IsPositiveInfinity(args[0]._dValue))
-                            pos0 = selfString.Length;
-                        else
-                            pos0 = (int)args[0]._dValue;
-                        break;
-                    }
-                case JSValueType.Object:
-                case JSValueType.Date:
-                case JSValueType.Function:
-                case JSValueType.String:
-                    {
-                        pos0 = Tools.JSObjectToInt32(args[0], 0, true);
-                        break;
-                    }
-            }
-            int pos1 = 0;
-            if (args.Length > 1)
-            {
-                switch (args[1]._valueType)
-                {
-                    case JSValueType.Integer:
-                    case JSValueType.Boolean:
-                        {
-                            pos1 = args[1]._iValue;
-                            break;
-                        }
-                    case JSValueType.Double:
-                        {
-                            if (double.IsNaN(args[1]._dValue) || double.IsNegativeInfinity(args[0]._dValue))
-                                pos1 = 0;
-                            else if (double.IsPositiveInfinity(args[1]._dValue))
-                                pos1 = selfString.Length;
-                            else
-                                pos1 = (int)args[1]._dValue;
-                            break;
-                        }
-                    case JSValueType.Object:
-                    case JSValueType.Date:
-                    case JSValueType.Function:
-                    case JSValueType.String:
-                        {
-                            //double d;
-                            //Tools.ParseNumber(args[1].ToPrimitiveValue_Value_String().ToString(), pos1, out d, Tools.ParseNumberOptions.Default);
-                            //pos1 = (int)d;
-                            pos1 = Tools.JSObjectToInt32(args[1], 0, true);
-                            break;
-                        }
-                    case JSValueType.NotExists:
-                    case JSValueType.NotExistsInObject:
-                    case JSValueType.Undefined:
-                        {
-                            pos1 = selfString.Length;
-                            break;
-                        }
-                }
-            }
-            else
-                pos1 = selfString.Length;
-            while (pos0 < 0)
-                pos0 += selfString.Length;
-            while (pos1 < 0)
-                pos1 += selfString.Length;
-            pos0 = System.Math.Min(pos0, selfString.Length);
-            return selfString.Substring(pos0, System.Math.Min(selfString.Length, System.Math.Max(0, pos1 - pos0)));
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.slice called on null or undefined"));
+
+            string selfStr = self.ToString();
+
+            if (args == null || args.Length == 0)
+                return self.ToString();
+
+            int pos0 = Tools.JSObjectToInt32(args[0], 0, 0, 0, true);
+            int pos1 = Tools.JSObjectToInt32(args[1], 0, selfStr.Length, 0, true);
+
+            if (pos0 < 0)
+                pos0 += selfStr.Length;
+            if (pos1 < 0)
+                pos1 += selfStr.Length;
+            pos0 = System.Math.Min(System.Math.Max(0, pos0), selfStr.Length);
+            pos1 = System.Math.Min(System.Math.Max(0, pos1), selfStr.Length);
+
+            if (pos0 >= pos1)
+                return new String();
+
+            return selfStr.Substring(pos0, pos1 - pos0);
         }
 
         [DoNotEnumerate]
@@ -605,8 +579,10 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(2)]
         public static JSValue split(JSValue self, Arguments args)
         {
-            if (self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
-                ExceptionHelper.Throw(new TypeError("String.prototype.match called on null or undefined"));
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.split called on null or undefined"));
+
+            var selfStr = self.ToString();
 
             if (args == null || args.Length == 0 || !args[0].Defined)
                 return new Array(new JSValue[] { self.ToString() });
@@ -614,7 +590,6 @@ namespace NiL.JS.BaseLibrary
             var a0 = args[0];
             var regex = a0?.Value as RegExp;
 
-            var selfString = self.ToString();
             var limit = (uint)Tools.JSObjectToInt64(args[1], long.MaxValue, true);
 
             if (limit == 0)
@@ -624,9 +599,9 @@ namespace NiL.JS.BaseLibrary
             {
                 var re = regex._regex;
 
-                var m = re.Match(selfString, 0);
+                var m = re.Match(selfStr, 0);
                 if (!m.Success)
-                    return new Array(new JSValue[] { selfString });
+                    return new Array(new JSValue[] { selfStr });
 
                 Array res = new Array();
 
@@ -638,18 +613,18 @@ namespace NiL.JS.BaseLibrary
 
                     if (!m.Success)
                     {
-                        res._data.Add(selfString.Substring(index, selfString.Length - index));
+                        res._data.Add(selfStr.Substring(index, selfStr.Length - index));
                         break;
                     }
 
-                    if (m.Index >= selfString.Length)
+                    if (m.Index >= selfStr.Length)
                         break;
 
                     int nindex = m.Index + (m.Length == 0 ? 1 : 0);
-                    var item = selfString.Substring(index, nindex - index);
+                    var item = selfStr.Substring(index, nindex - index);
                     res._data.Add(item);
 
-                    if (nindex < selfString.Length)
+                    if (nindex < selfStr.Length)
                     {
                         for (int i = 1; i < m.Groups.Count; i++)
                         {
@@ -670,10 +645,10 @@ namespace NiL.JS.BaseLibrary
 
                 if (string.IsNullOrEmpty(fstr))
                 {
-                    int len = System.Math.Min(selfString.Length, (int)System.Math.Min(int.MaxValue, limit));
+                    int len = System.Math.Min(selfStr.Length, (int)System.Math.Min(int.MaxValue, limit));
                     var arr = new JSValue[len];
                     for (var i = 0; i < len; i++)
-                        arr[i] = new String(selfString[i].ToString());
+                        arr[i] = new String(selfStr[i].ToString());
                     return new Array(arr);
                 }
                 else
@@ -682,15 +657,15 @@ namespace NiL.JS.BaseLibrary
                     int index = 0;
                     while (res._data.Length < limit)
                     {
-                        int nindex = selfString.IndexOf(fstr, index, StringComparison.Ordinal);
+                        int nindex = selfStr.IndexOf(fstr, index, StringComparison.Ordinal);
                         if (nindex == -1)
                         {
-                            res._data.Add(selfString.Substring(index, selfString.Length - index));
+                            res._data.Add(selfStr.Substring(index, selfStr.Length - index));
                             break;
                         }
                         else
                         {
-                            res._data.Add(selfString.Substring(index, nindex - index));
+                            res._data.Add(selfStr.Substring(index, nindex - index));
                             index = nindex + fstr.Length;
                         }
                     }
@@ -704,10 +679,14 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(1)]
         public static JSValue startsWith(JSValue self, Arguments args)
         {
-            var selfAsString = (self ?? undefinedString).ToString();
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.startsWith called on null or undefined"));
+
+            var selfStr = self.ToString();
+
             var value = (args?[0] ?? undefinedString).ToString();
 
-            return selfAsString.StartsWith(value) ? Boolean.True : Boolean.False;
+            return selfStr.StartsWith(value, StringComparison.Ordinal) ? Boolean.True : Boolean.False;
         }
 
         [DoNotEnumerate]
@@ -715,12 +694,16 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(2)]
         public static JSValue substring(JSValue self, Arguments args)
         {
-            string selfString = self.ToString();
-            if (args.Length == 0)
-                return selfString;
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.substring called on null or undefined"));
+
+            var selfStr = self.ToString();
+
+            if (args == null || args.Length == 0)
+                return self.ToString();
 
             int pos0 = Tools.JSObjectToInt32(args[0], 0, 0, 0, true);
-            int pos1 = Tools.JSObjectToInt32(args[1], 0, selfString.Length, 0, true);
+            int pos1 = Tools.JSObjectToInt32(args[1], 0, selfStr.Length, 0, true);
 
             if (pos0 > pos1)
             {
@@ -729,10 +712,10 @@ namespace NiL.JS.BaseLibrary
                 pos0 ^= pos1;
             }
 
-            pos0 = System.Math.Max(0, System.Math.Min(pos0, selfString.Length));
-            pos1 = System.Math.Max(0, System.Math.Min(pos1, selfString.Length));
+            pos0 = System.Math.Max(0, System.Math.Min(pos0, selfStr.Length));
+            pos1 = System.Math.Max(0, System.Math.Min(pos1, selfStr.Length));
 
-            return selfString.Substring(pos0, System.Math.Min(selfString.Length, System.Math.Max(0, pos1 - pos0)));
+            return selfStr.Substring(pos0, System.Math.Min(selfStr.Length, System.Math.Max(0, pos1 - pos0)));
         }
 
         [DoNotEnumerate]
@@ -740,25 +723,28 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(2)]
         public static JSValue substr(JSValue self, Arguments args)
         {
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.substr called on null or undefined"));
+
+            var selfStr = self.ToString();
+
             if (args.Length == 0)
                 return self;
 
-            var selfString = self.ToString();
-
             int start = Tools.JSObjectToInt32(args[0], 0, 0, 0, true);
-            int length = Tools.JSObjectToInt32(args[1], 0, selfString.Length, 0, true);
+            int length = Tools.JSObjectToInt32(args[1], 0, selfStr.Length, 0, true);
 
             if (start < 0)
-                start += selfString.Length;
+                start += selfStr.Length;
             if (start < 0)
                 start = 0;
-            if (start >= selfString.Length || length <= 0)
+            if (start >= selfStr.Length || length <= 0)
                 return "";
 
-            if (selfString.Length < start + length)
-                length = selfString.Length - start;
+            if (selfStr.Length < start + length)
+                length = selfStr.Length - start;
 
-            return selfString.Substring(start, length);
+            return selfStr.Substring(start, length);
         }
 
         [DoNotEnumerate]
@@ -766,11 +752,10 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(0)]
         public static JSValue toLocaleLowerCase(JSValue self)
         {
-            var sstr = self.ToString();
-            var res = sstr.ToLower();
-            if (self._valueType == JSValueType.String && string.CompareOrdinal(sstr, res) == 0)
-                return self;
-            return res;
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.toLocaleLowerCase called on null or undefined"));
+
+            return self.ToString().ToLower();
         }
 
         [DoNotEnumerate]
@@ -778,11 +763,10 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(0)]
         public static JSValue toLocaleUpperCase(JSValue self)
         {
-            var sstr = self.ToString();
-            var res = sstr.ToUpper();
-            if (self._valueType == JSValueType.String && string.CompareOrdinal(sstr, res) == 0)
-                return self;
-            return res;
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.toLocaleUpperCase called on null or undefined"));
+
+            return self.ToString().ToUpper();
         }
 
         [DoNotEnumerate]
@@ -790,11 +774,10 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(0)]
         public static JSValue toLowerCase(JSValue self)
         {
-            var sstr = self.ToString();
-            var res = sstr.ToLowerInvariant();
-            if (self._valueType == JSValueType.String && string.CompareOrdinal(sstr, res) == 0)
-                return self;
-            return res;
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.toLowerCase called on null or undefined"));
+
+            return self.ToString().ToLowerInvariant();
         }
 
         [DoNotEnumerate]
@@ -802,11 +785,10 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(0)]
         public static JSValue toUpperCase(JSValue self)
         {
-            var sstr = self.ToString();
-            var res = sstr.ToUpperInvariant();
-            if (self._valueType == JSValueType.String && string.CompareOrdinal(sstr, res) == 0)
-                return self;
-            return res;
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.toUpperCase called on null or undefined"));
+
+            return self.ToString().ToUpperInvariant();
         }
 
         [DoNotEnumerate]
@@ -814,24 +796,9 @@ namespace NiL.JS.BaseLibrary
         [ArgumentsCount(0)]
         public static JSValue trim(JSValue self)
         {
-            switch (self._valueType)
-            {
-                case JSValueType.Undefined:
-                case JSValueType.NotExists:
-                case JSValueType.NotExistsInObject:
-                    {
-                        ExceptionHelper.Throw(new TypeError("string can't be undefined"));
-                        break;
-                    }
-                case JSValueType.Function:
-                case JSValueType.String:
-                case JSValueType.Object:
-                    {
-                        if (self._oValue == null)
-                            ExceptionHelper.Throw(new TypeError("string can't be null"));
-                        break;
-                    }
-            }
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.trim called on null or undefined"));
+
             try
             {
                 var sb = new StringBuilder(self.ToString());
@@ -986,6 +953,7 @@ namespace NiL.JS.BaseLibrary
                     if (f.Value.Exists && (!hideNonEnum || (f.Value._attributes & JSValueAttributesInternal.DoNotEnumerate) == 0))
                         yield return f;
                 }
+
             }
         }
 
@@ -1007,99 +975,138 @@ namespace NiL.JS.BaseLibrary
             return result.ToString();
         }
 
-        #region HTML Wraping
+        #region HTML Wrapping
         [DoNotEnumerate]
         [InstanceMember]
         public static JSValue anchor(JSValue self, Arguments arg)
         {
-            return "<a name=\"" + arg[0].Value + "\">" + self + "</a>";
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.anchor called on null or undefined"));
+
+            return "<a name=\"" + arg[0].Value + "\">" + self.ToString() + "</a>";
         }
 
         [DoNotEnumerate]
         [InstanceMember]
         public static JSValue big(JSValue self)
         {
-            return "<big>" + self + "</big>";
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.big called on null or undefined"));
+
+            return "<big>" + self.ToString() + "</big>";
         }
 
         [DoNotEnumerate]
         [InstanceMember]
         public static JSValue blink(JSValue self)
         {
-            return "<blink>" + self + "</blink>";
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.blink called on null or undefined"));
+
+            return "<blink>" + self.ToString() + "</blink>";
         }
 
         [DoNotEnumerate]
         [InstanceMember]
         public static JSValue bold(JSValue self)
         {
-            return "<bold>" + self + "</bold>";
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.bold called on null or undefined"));
+
+            return "<bold>" + self.ToString() + "</bold>";
         }
 
         [DoNotEnumerate]
         [InstanceMember]
         public static JSValue @fixed(JSValue self)
         {
-            return "<tt>" + self + "</tt>";
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.fixed called on null or undefined"));
+
+            return "<tt>" + self.ToString() + "</tt>";
         }
 
         [DoNotEnumerate]
         [InstanceMember]
         public static JSValue fontcolor(JSValue self, Arguments arg)
         {
-            return "<font color=\"" + arg[0].Value + "\">" + self + "</font>";
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.fontcolor called on null or undefined"));
+
+            return "<font color=\"" + arg[0].Value + "\">" + self.ToString() + "</font>";
         }
 
         [DoNotEnumerate]
         [InstanceMember]
         public static JSValue fontsize(JSValue self, Arguments arg)
         {
-            return "<font size=\"" + arg.Value + "\">" + self + "</font>";
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.fontsize called on null or undefined"));
+
+            return "<font size=\"" + arg.Value + "\">" + self.ToString() + "</font>";
         }
 
         [DoNotEnumerate]
         [InstanceMember]
         public static JSValue italics(JSValue self)
         {
-            return "<i>" + self + "</i>";
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.italics called on null or undefined"));
+
+            return "<i>" + self.ToString() + "</i>";
         }
 
         [DoNotEnumerate]
         [InstanceMember]
         public static JSValue link(JSValue self, Arguments arg)
         {
-            return "<a href=\"" + arg[0].Value + "\">" + self + "</a>";
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.link called on null or undefined"));
+
+            return "<a href=\"" + arg[0].Value + "\">" + self.ToString() + "</a>";
         }
 
         [DoNotEnumerate]
         [InstanceMember]
         public static JSValue small(JSValue self)
         {
-            return "<small>" + self + "</small>";
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.small called on null or undefined"));
+
+            return "<small>" + self.ToString() + "</small>";
         }
 
         [DoNotEnumerate]
         [InstanceMember]
         public static JSValue strike(JSValue self)
         {
-            return "<strike>" + self + "</strike>";
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.strike called on null or undefined"));
+
+            return "<strike>" + self.ToString() + "</strike>";
         }
 
         [DoNotEnumerate]
         [InstanceMember]
         public static JSValue sub(JSValue self)
         {
-            return "<sub>" + self + "</sub>";
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.sub called on null or undefined"));
+
+            return "<sub>" + self.ToString() + "</sub>";
         }
 
         [DoNotEnumerate]
         [InstanceMember]
         public static JSValue sup(JSValue self)
         {
-            return "<sup>" + self + "</sup>";
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.sup called on null or undefined"));
+
+            return "<sup>" + self.ToString() + "</sup>";
         }
         #endregion
-        
+
         [Hidden]
         public static implicit operator String(string val)
         {

--- a/NiL.JS/BaseLibrary/String.cs
+++ b/NiL.JS/BaseLibrary/String.cs
@@ -42,13 +42,13 @@ namespace NiL.JS.BaseLibrary
                 if (n._valueType == JSValueType.Integer)
                 {
                     if (n._iValue < 0 || n._iValue > 0x10FFFF)
-                        ExceptionHelper.Throw((new RangeError("Invalid code point " + Tools.Int32ToString(n._iValue))));
+                        ExceptionHelper.Throw(new RangeError("Invalid code point " + Tools.Int32ToString(n._iValue)));
                     ucs = (uint)n._iValue;
                 }
                 else if (n._valueType == JSValueType.Double)
                 {
                     if (n._dValue < 0 || n._dValue > 0x10FFFF || double.IsInfinity(n._dValue) || double.IsNaN(n._dValue) || n._dValue % 1.0 != 0.0)
-                        ExceptionHelper.Throw((new RangeError("Invalid code point " + Tools.DoubleToString(n._dValue))));
+                        ExceptionHelper.Throw(new RangeError("Invalid code point " + Tools.DoubleToString(n._dValue)));
                     ucs = (uint)n._dValue;
                 }
 
@@ -62,7 +62,7 @@ namespace NiL.JS.BaseLibrary
                     res += h.ToString() + l.ToString();
                 }
                 else
-                    ExceptionHelper.Throw((new RangeError("Invalid code point " + ucs.ToString())));
+                    ExceptionHelper.Throw(new RangeError("Invalid code point " + ucs.ToString()));
             }
             return res;
         }

--- a/NiL.JS/BaseLibrary/String.cs
+++ b/NiL.JS/BaseLibrary/String.cs
@@ -409,77 +409,79 @@ namespace NiL.JS.BaseLibrary
         {
             if (args == null || args.length == 0)
                 return self;
-            if ((args[0] ?? @null)._valueType == JSValueType.Object
-                && (args[0] ?? @null).Value != null
-                && args[0].Value.GetType() == typeof(RegExp))
+
+            var a0 = args[0];
+            var regex = a0?.Value as RegExp;
+
+            var a1 = args[1];
+            var f = a1?.Value as Function;
+
+            var selfStr = self.ToString();
+
+            if (regex != null)
             {
-                var f = args[1]._oValue as Function;
-                if (args.length > 1 && f != null)
+                var re = regex._regex;
+                if (f != null)
                 {
-                    string temp = self._oValue.ToString();
+                    var str = new String(selfStr);
                     var match = new String();
-                    var margs = new Arguments();
-                    match._oValue = (args[0]._oValue as RegExp)._Regex.Replace(self.ToString(),
+                    var fArgs = new Arguments();
+                    return re.Replace(
+                        selfStr,
                         (m) =>
                         {
-                            self._oValue = temp;
-                            self._valueType = JSValueType.String;
-                            margs.length = m.Groups.Count + 2;
-
-                            JSValue t;
-                            for (int i = 1; i < m.Groups.Count; i++)
-                            {
-                                t = m.Groups[i].Value;
-                                margs[i] = t;
-                            }
-
-                            t = m.Index;
+                            str._oValue = selfStr;
+                            str._valueType = JSValueType.String;
                             match._oValue = m.Value;
-                            margs[0] = match;
-                            margs[margs.length - 2] = t;
-                            margs[margs.length - 1] = self;
+                            match._valueType = JSValueType.String;
 
-                            return f.Call(margs).ToString();
-                        }, (args[0].Value as RegExp)._global ? int.MaxValue : 1);
-                    self._oValue = temp;
-                    self._valueType = JSValueType.String;
-                    return match;
+                            fArgs.length = m.Groups.Count + 2;
+                            fArgs[0] = match;
+
+                            for (int i = 1; i < m.Groups.Count; i++)
+                                fArgs[i] = m.Groups[i].Value;
+
+                            fArgs[fArgs.length - 2] = m.Index;
+                            fArgs[fArgs.length - 1] = str;
+
+                            return f.Call(fArgs).ToString();
+                        },
+                        regex._global ? int.MaxValue : 1);
                 }
                 else
                 {
-                    return (args[0].Value as RegExp)._Regex.Replace(self.ToString(), args.Length > 1 ? args[1].ToString() : "undefined", (args[0].Value as RegExp)._global ? int.MaxValue : 1);
+                    string replacement = args.Length > 1 ? (a1 ?? "").ToString() : "undefined";
+                    return re.Replace(selfStr, replacement, regex._global ? int.MaxValue : 1);
                 }
             }
             else
             {
-                string pattern = args.Length > 0 ? args[0].ToString() : "";
-                var f = args[1]._oValue as Function;
-                if (args.Length > 1 && f != null)
+                string pattern = (a0 ?? "").ToString();
+                if (f != null)
                 {
-                    string othis = self._oValue.ToString();
-                    var margs = new Arguments();
-                    margs.length = 3;
-                    margs[0] = pattern;
-                    margs[2] = self;
-                    int index = self.ToString().IndexOf(pattern);
+                    int index = selfStr.IndexOf(pattern);
                     if (index == -1)
-                        return self;
-                    margs[1] = index;
-                    var res = othis.Substring(0, index) + f.Call(margs).ToString() + othis.Substring(index + pattern.Length);
-                    self._oValue = othis;
-                    self._valueType = JSValueType.String;
-                    return res;
+                        return selfStr;
+
+                    var fArgs = new Arguments();
+                    fArgs.length = 3;
+                    fArgs[0] = pattern;
+                    fArgs[1] = index;
+                    fArgs[2] = self;
+
+                    return selfStr.Substring(0, index) + f.Call(fArgs).ToString() + selfStr.Substring(index + pattern.Length);
                 }
                 else
                 {
-                    string replace = args.Length > 1 ? args[1].ToString() : "undefined";
-                    if (string.IsNullOrEmpty(pattern))
-                        return replace + self;
-                    var str = self.ToString();
-                    var index = str.IndexOf(pattern);
+                    string replacement = args.Length > 1 ? (a1 ?? "").ToString() : "undefined";
+                    if (pattern.Length == 0)
+                        return replacement + selfStr;
+
+                    var index = selfStr.IndexOf(pattern);
                     if (index == -1)
-                        return self;
-                    return str.Substring(0, index) + replace + str.Substring(index + pattern.Length);
+                        return selfStr;
+
+                    return selfStr.Substring(0, index) + replacement + selfStr.Substring(index + pattern.Length);
                 }
             }
         }

--- a/NiL.JS/BaseLibrary/String.cs
+++ b/NiL.JS/BaseLibrary/String.cs
@@ -326,6 +326,83 @@ namespace NiL.JS.BaseLibrary
 
         [DoNotEnumerate]
         [InstanceMember]
+        [ArgumentsCount(1)]
+        public static JSValue normalize(JSValue self, Arguments args)
+        {
+            var selfStr = (self ?? undefinedString).ToString();
+
+            var form = "NFC";
+            if (args != null && args.Length > 0)
+            {
+                var a0 = args[0];
+                if (a0 != null && a0._valueType > JSValueType.Undefined)
+                    form = a0.ToString();
+            }
+
+            switch (form)
+            {
+                case "NFC":
+                    {
+                        selfStr = selfStr.Normalize(NormalizationForm.FormC);
+                        break;
+                    }
+                case "NFD":
+                    {
+                        selfStr = selfStr.Normalize(NormalizationForm.FormD);
+                        break;
+                    }
+                case "NFKC":
+                    {
+                        selfStr = selfStr.Normalize(NormalizationForm.FormKC);
+                        break;
+                    }
+                case "NFKD":
+                    {
+                        selfStr = selfStr.Normalize(NormalizationForm.FormKD);
+                        break;
+                    }
+                default:
+                    ExceptionHelper.Throw(new RangeError("The normalization form should be one of NFC, NFD, NFKC, NFKD"));
+                    break;
+            }
+            return selfStr;
+        }
+
+        [DoNotEnumerate]
+        [InstanceMember]
+        [ArgumentsCount(1)]
+        public static JSValue repeat(JSValue self, Arguments args)
+        {
+            var selfStr = (self ?? undefinedString).ToString();
+
+            double count = 0;
+            if (args.Length > 0)
+                count = Tools.JSObjectToDouble(args[0]);
+            if (double.IsNaN(count))
+                count = 0;
+            count = System.Math.Truncate(count);
+
+            if (count < 0 || double.IsInfinity(count))
+                ExceptionHelper.Throw(new RangeError("Invalid count value"));
+
+            int c = (int)count;
+
+            if (c == 0)
+                return "";
+            if (c == 1)
+                return selfStr;
+            if (selfStr.Length == 0)
+                return "";
+
+            var s = new StringBuilder(selfStr.Length * c);
+            for (int i = 0; i < c; i++)
+                s.Append(selfStr);
+
+            return s.ToString();
+        }
+
+        [DoNotEnumerate]
+        [InstanceMember]
         [ArgumentsCount(2)]
         [AllowNullArguments]
         public static JSValue replace(JSValue self, Arguments args)

--- a/NiL.JS/BaseLibrary/String.cs
+++ b/NiL.JS/BaseLibrary/String.cs
@@ -370,6 +370,84 @@ namespace NiL.JS.BaseLibrary
 
         [DoNotEnumerate]
         [InstanceMember]
+        [ArgumentsCount(2)]
+        public static JSValue padEnd(JSValue self, Arguments args)
+        {
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.codePointAt called on null or undefined"));
+
+            var selfStr = self.ToString();
+
+            if (args == null || args.Length == 0)
+                return selfStr;
+
+            int p = Tools.JSObjectToInt32(args[0], true);
+            if (p <= selfStr.Length)
+                return selfStr;
+
+            if (args.Length >= 2 && args[1] != null && args[1].Defined)
+            {
+                string filler = args[1].ToString();
+
+                if (string.IsNullOrEmpty(filler))
+                    return selfStr;
+                if (filler.Length == 1)
+                    return selfStr.PadRight(p, filler[0]);
+
+                var s = new StringBuilder(p);
+
+                s.Append(selfStr);
+                for (int i = p / filler.Length - 1; i >= 0; i--)
+                    s.Append(filler);
+                s.Append(filler.Substring(0, p % filler.Length));
+
+                return s.ToString();
+            }
+
+            return selfStr.PadRight(p, ' ');
+        }
+
+        [DoNotEnumerate]
+        [InstanceMember]
+        [ArgumentsCount(2)]
+        public static JSValue padStart(JSValue self, Arguments args)
+        {
+            if (self == null || self._valueType <= JSValueType.Undefined || (self._valueType >= JSValueType.Object && self.Value == null))
+                ExceptionHelper.Throw(new TypeError("String.prototype.codePointAt called on null or undefined"));
+
+            var selfStr = self.ToString();
+
+            if (args == null || args.Length == 0)
+                return selfStr;
+
+            int p = Tools.JSObjectToInt32(args[0], true);
+            if (p <= selfStr.Length)
+                return selfStr;
+
+            if (args.Length >= 2 && args[1] != null && args[1].Defined)
+            {
+                string filler = args[1].ToString();
+
+                if (string.IsNullOrEmpty(filler))
+                    return selfStr;
+                if (filler.Length == 1)
+                    return selfStr.PadLeft(p, filler[0]);
+
+                var s = new StringBuilder(p);
+
+                for (int i = p / filler.Length - 1; i >= 0; i--)
+                    s.Append(filler);
+                s.Append(filler.Substring(0, p % filler.Length));
+                s.Append(selfStr);
+
+                return s.ToString();
+            }
+
+            return selfStr.PadLeft(p, ' ');
+        }
+
+        [DoNotEnumerate]
+        [InstanceMember]
         [ArgumentsCount(1)]
         public static JSValue repeat(JSValue self, Arguments args)
         {

--- a/NiL.JS/BaseLibrary/String.cs
+++ b/NiL.JS/BaseLibrary/String.cs
@@ -641,7 +641,7 @@ namespace NiL.JS.BaseLibrary
             var selfStr = self.ToString();
 
             if (args == null || args.Length == 0 || !args[0].Defined)
-                return new Array(new JSValue[] { self.ToString() });
+                return new Array { selfStr };
 
             var a0 = args[0];
             var regex = a0?.Value as RegExp;

--- a/NiL.JS/Core/Parser.cs
+++ b/NiL.JS/Core/Parser.cs
@@ -423,16 +423,6 @@ namespace NiL.JS.Core
                     if (j >= code.Length)
                         break;
                     char c = code[j];
-                    if (c == '\\')
-                    {
-                        int len = 1;
-                        if (code[j + 1] == 'u')
-                            len = 5;
-                        else if (code[j + 1] == 'x')
-                            len = 3;
-                        c = Tools.Unescape(code.Substring(j, len + 1), false)[0];
-                        j += len;
-                    }
                     switch (c)
                     {
                         case 'g':

--- a/NiL.JS/Core/Parser.cs
+++ b/NiL.JS/Core/Parser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -429,7 +429,7 @@ namespace NiL.JS.Core
                             {
                                 if (g)
                                     if (throwError)
-                                        throw new ArgumentException("Invalid flag in regexp definition");
+                                        throw new ArgumentException("Invalid flag in RegExp definition");
                                     else
                                         return false;
                                 g = true;
@@ -439,22 +439,42 @@ namespace NiL.JS.Core
                             {
                                 if (i)
                                     if (throwError)
-                                        throw new ArgumentException("Invalid flag in regexp definition");
+                                        throw new ArgumentException("Invalid flag in RegExp definition");
                                     else
                                         return false;
                                 i = true;
                                 break;
-                            }
-                        case 'm':
-                            {
-                                if (m)
-                                    if (throwError)
-                                        throw new ArgumentException("Invalid flag in regexp definition");
-                                    else
-                                        return false;
-                                m = true;
-                                break;
-                            }
+							}
+						case 'm':
+							{
+								if (m)
+									if (throwError)
+										throw new ArgumentException("Invalid flag in RegExp definition");
+									else
+										return false;
+								m = true;
+								break;
+							}
+						case 'u':
+							{
+								if (u)
+									if (throwError)
+										throw new ArgumentException("Invalid flag in RegExp definition");
+									else
+										return false;
+								u = true;
+								break;
+							}
+						case 'y':
+							{
+								if (y)
+									if (throwError)
+										throw new ArgumentException("Invalid flag in RegExp definition");
+									else
+										return false;
+								y = true;
+								break;
+							}
                         default:
                             {
                                 if (IsIdentifierTerminator(c))

--- a/NiL.JS/Core/SparseArray.cs
+++ b/NiL.JS/Core/SparseArray.cs
@@ -67,6 +67,14 @@ namespace NiL.JS.Core
                 ensureCapacity(capacity);
         }
 
+        public SparseArray(TValue[] values)
+        {
+            mode = ArrayMode.Flat;
+            this.values = values;
+            navyData = emptyNavyData;
+            allocatedCount = (pseudoLength = (uint)values.Length);
+        }
+
         #region Члены IList<TValue>
 
         public int IndexOf(TValue item)

--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -86,7 +86,7 @@ namespace NiL.JS.Core
     {
         private static readonly Type[] intTypeWithinArray = new[] { typeof(int) };
 
-        internal static readonly char[] TrimChars = new[] { '\u0009', '\u000A', '\u000B', '\u000C', '\u000D', '\u0020', '\u00A0', '\u1680', '\u180E', '\u2000', '\u2001', '\u2002', '\u2003', '\u2004', '\u2005', '\u2006', '\u2007', '\u2008', '\u2009', '\u200A', '\u2028', '\u2029', '\u202F', '\u205F', '\u3000', '\uFEFF' };
+        internal static readonly char[] TrimChars = new[] { '\u0020', '\u0009', '\u000A', '\u000D', '\u000B', '\u000C', '\u00A0', '\u1680', '\u180E', '\u2000', '\u2001', '\u2002', '\u2003', '\u2004', '\u2005', '\u2006', '\u2007', '\u2008', '\u2009', '\u200A', '\u2028', '\u2029', '\u202F', '\u205F', '\u3000', '\uFEFF' };
 
         internal static readonly char[] NumChars = new[]
         {

--- a/NiL.JS/Expressions/RegExpCreate.cs
+++ b/NiL.JS/Expressions/RegExpCreate.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NiL.JS.BaseLibrary;
 using NiL.JS.Core;
 using NiL.JS.Statements;
@@ -71,7 +71,7 @@ namespace NiL.JS.Expressions
 
         public override JSValue Evaluate(Context context)
         {
-            return new RegExp(pattern, flags);
+            return new RegExp(pattern, flags, false);
         }
 
         public override T Visit<T>(Visitor<T> visitor)


### PR DESCRIPTION
# Text processing

This adds new functionality to String and RegExp.

## RegExp

RegExp will now cache the underlying Regexes for increased performance.

### Flags

RegExp now supports the sticky flag `y` and the Unicode flag `u`. They will each have their own instance property `sticky` and `unicode` respectively. Both will be visible with `[RegExp].ToString()` (where flags are now alphabetically sorted).

The sticky flag changes the behaviour of the following functions:
- RegExp: `exec`, `test`
- String: `match`

The Unicode flag will enable the new Unicode escape `\u{...}` and will translate the pattern into an ES5 version that behaves like an ES6 Unicode version would. This has to be done because the underlying Regex class only work with ES5 patterns.
`[RegExp].source` and `[RegExp].toString` will continue to show the original version.

## String

The String class has been cleaned up.
They will now all convert arguments and check for null/undefined in the same way.
All functions will now check if they are being called by null or undefined and throw an error if so. (This behaviour could possibly be outsourced in the future; A lot of functions share this behaviour.)

### New

`codePointAt`, `fromCodePoint`, `normalize`, `repeat`, `padEnd`, `padStart`

### Updated

- `split` will now insert capturing groups (and behave correctly in all edge cases I tested).
- `trim` will now use the native `[string].Trim` function as it is both faster and less complicated.
- The enumerator will now treat Unicode surrogate pairs as one character.

### RegExp

All RegExp related functions have been rewritten to behave more like the ES6 Standard and to be more efficient.

## Array

Some small changes

- A new constructor (internal) to create an Array directly from a JSValue array. This should be used if a function fills an array of fixed length as it is significantly faster.
- `Array.of` was added.
- `Array.join` is now slightly faster.

## Other

- I changed `Tools.Unescape` to correctly unescape `\u{...}` (can be disabled).
- `Tools.UnescapeNextChar` should now be used to unescape char wise. (We might want to change the signature)
- `Tools.NextCodePoint`, `Tools.IsSurrogatePair`, `Tools.CodePointToString` can be used to better detect and handle Unicode text.