### PR TITLE
Fix for Text processing

### DIFF
--- a/NiL.JS/BaseLibrary/String.cs
+++ b/NiL.JS/BaseLibrary/String.cs
@@ -291,7 +291,7 @@ namespace NiL.JS.BaseLibrary
             var regex = a0.Value as RegExp;
 
             if (regex == null)
-                regex = new RegExp((a0._valueType > JSValueType.Undefined ? (object)a0 : "").ToString(), "", false); // cached
+                regex = new RegExp((a0._valueType > JSValueType.Undefined ? (object)a0 : "").ToString(), ""); // cached
 
             if (!regex._global)
             {

--- a/NiL.JS/Core/Parser.cs
+++ b/NiL.JS/Core/Parser.cs
@@ -416,7 +416,7 @@ namespace NiL.JS.Core
                     return false;
 
                 bool w = true;
-                bool g = false, i = false, m = false;
+                bool g = false, i = false, m = false, u = false, y = false;
                 while (w)
                 {
                     j++;

--- a/NiL.JS/Expressions/RegExpCreate.cs
+++ b/NiL.JS/Expressions/RegExpCreate.cs
@@ -71,7 +71,7 @@ namespace NiL.JS.Expressions
 
         public override JSValue Evaluate(Context context)
         {
-            return new RegExp(pattern, flags, false);
+            return new RegExp(pattern, flags);
         }
 
         public override T Visit<T>(Visitor<T> visitor)


### PR DESCRIPTION
When I removed to RegExp constructor with `bool unescapeFlag` I forgot that some functions use this constructor. I also forgot to commit a change I made to `Parser.cs`.