### PR TITLE
Fixed errors parsing slashes or comment style comments withing interpolation strings

### DIFF
--- a/FunctionalTests/FunctionalTests.csproj
+++ b/FunctionalTests/FunctionalTests.csproj
@@ -84,6 +84,7 @@
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
     </Compile>
+    <Compile Include="StringInterpolationTests.cs" />
     <Compile Include="MemberAlias.cs" />
     <Compile Include="JsFunfuzz.cs" />
     <Compile Include="OverloadedMethods.cs" />

--- a/FunctionalTests/StringInterpolationTests.cs
+++ b/FunctionalTests/StringInterpolationTests.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NiL.JS.Core;
+
+namespace FunctionalTests
+{
+    [TestClass]
+    public sealed class StringInterpolationTests
+    {
+        [TestMethod]
+        public void StringInterpolationAllowsStrings()
+        {
+            var context = new Context();
+            var code = @"`This is a string`";
+            var stringValue = context.Eval(code);
+
+            Assert.AreEqual("This is a string", stringValue.Value);
+        }
+
+        [TestMethod]
+        public void StringInterpolationAllowsSlashes()
+        {
+            var context = new Context();
+            var code = @"`This is a string such as http://www.google.com`";
+            var stringValue = context.Eval(code);
+            Assert.AreEqual("This is a string such as http://www.google.com", stringValue.Value);
+        }
+
+        [TestMethod]
+        public void StringAllowsSlashes()
+        {
+            var context = new Context();
+            var code = @"'This is a string such as http://www.google.com'";
+            var stringValue = context.Eval(code);
+            Assert.AreEqual("This is a string such as http://www.google.com", stringValue.Value);
+        }
+
+        [TestMethod]
+        public void StringAllowsSlashesDoubleQuoted()
+        {
+            var context = new Context();
+            var code = @"""This is a string such as http://www.google.com""";
+            var stringValue = context.Eval(code);
+            Assert.AreEqual("This is a string such as http://www.google.com", stringValue.Value);
+        }
+
+        [TestMethod]
+        public void StringInterpolationAllowsSubstititions()
+        {
+            var context = new Context();
+            var code = @"var a=1234; `This is a string such as ${a}`";
+            var stringValue = context.Eval(code);
+
+            Assert.AreEqual("This is a string such as 1234", stringValue.Value);
+        }
+    }
+}

--- a/NiL.JS/Core/Parser.cs
+++ b/NiL.JS/Core/Parser.cs
@@ -507,7 +507,7 @@ namespace NiL.JS.Core
         public static bool ValidateString(string code, ref int index, bool @throw)
         {
             int j = index;
-            if (j + 1 < code.Length && ((code[j] == '\'') || (code[j] == '"')))
+            if (j + 1 < code.Length && ((code[j] == '\'') || (code[j] == '"') || (code[j] == '`')))
             {
                 char fchar = code[j];
                 j++;


### PR DESCRIPTION
Fixed issue #109 by including back-tick as a string delimiter
Also added basic String Interpolation tests