### PR TITLE
Fix JSON.stringify spacing

### DIFF
--- a/IntegrationTests/BaseLibrary/JsonTests.cs
+++ b/IntegrationTests/BaseLibrary/JsonTests.cs
@@ -1,8 +1,15 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NiL.JS.Core;
-
-namespace IntegrationTests.BaseLibrary
+﻿namespace IntegrationTests.BaseLibrary
 {
+    using System;
+    using System.Collections.Generic;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using NiL.JS.BaseLibrary;
+    using NiL.JS.Core;
+
+    using Array = NiL.JS.BaseLibrary.Array;
+
     [TestClass]
     public sealed class JsonTests
     {
@@ -13,9 +20,40 @@ namespace IntegrationTests.BaseLibrary
         {
             string json = "\"a\":0";
 
-            NiL.JS.BaseLibrary.JSON.parse(json);
+            JSON.parse(json);
 
             Assert.Fail();
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void SpacingWhenStringifying()
+        {
+            var obj = JSObject.CreateObject();
+            obj.DefineProperty("test").Assign(123);
+            obj.DefineProperty("array").Assign(new Array(new List<JSValue> { JSValue.Marshal(123), JSValue.Marshal("test") }));
+            var nestedObj = JSObject.CreateObject();
+            nestedObj.DefineProperty("nil").Assign("JS!");
+            nestedObj.DefineProperty("null").Assign(JSValue.Null);
+            obj.DefineProperty("nested").Assign(nestedObj);
+
+            var expected3 = new[] { "{", "   \"test\": 123,", "   \"array\": [", "      123,", "      \"test\"", "   ],", "   \"nested\": {", "      \"nil\": \"JS!\"", "   }", "}" };
+            Assert.AreEqual(string.Join(Environment.NewLine, expected3), JSON.stringify(new Arguments { obj, null, 3 }));
+
+            var expected2 = new[] { "{", "  \"test\": 123,", "  \"array\": [", "    123,", "    \"test\"", "  ],", "  \"nested\": {", "    \"nil\": \"JS!\"", "  }", "}" };
+            Assert.AreEqual(string.Join(Environment.NewLine, expected2), JSON.stringify(new Arguments { obj, null, 2 }));
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void Max10SpacesWhenStringifying()
+        {
+            var obj = JSObject.CreateObject();
+            obj.DefineProperty("test").Assign(123);
+            obj.DefineProperty("array").Assign(new Array(new List<JSValue> { JSValue.Marshal(123), JSValue.Marshal("test") }));
+
+            var expected3 = new[] { "{", "          \"test\": 123,", "          \"array\": [", "                    123,", "                    \"test\"", "          ]", "}" };
+            Assert.AreEqual(string.Join(Environment.NewLine, expected3), JSON.stringify(new Arguments { obj, null, 15 }));
         }
     }
 }

--- a/NiL.JS/BaseLibrary/JSON.cs
+++ b/NiL.JS/BaseLibrary/JSON.cs
@@ -528,18 +528,16 @@ namespace NiL.JS.BaseLibrary
                         {
                             var prevIndex = int.Parse(prevKey ?? "-1");
 
-                            var capacity = result.Length + ((space != null ? space.Length : 0) + "null,".Length) * (curentIndex - prevIndex);
+                            var capacity = result.Length + "null,".Length * (curentIndex - prevIndex);
                             if (capacity > result.Length) // Может произойти переполнение
                                 result.EnsureCapacity(capacity);
 
                             for (var i = curentIndex - 1; i-- > prevIndex;)
                             {
-                                result.Append(space)
-                                   .Append("null,");
+                                result.Append("null,");
                             }
 
-                            result.Append(space)
-                               .Append(stringValue);
+                            result.Append(stringValue);
 
                             prevKey = member.Key;
                         }
@@ -551,7 +549,7 @@ namespace NiL.JS.BaseLibrary
                             escapeIfNeed(result, member.Key[i]);
 
                         result.Append("\":")
-                           .Append(space ?? "");
+                           .Append(space == null ? string.Empty : " ");
 
                         for (var i = 0; i < stringValue.Length; i++)
                         {


### PR DESCRIPTION
`JSON.stringify` was generating invalid gaps.

`JSON.stringify({a:1,b:[1,2]}, null, 2)` would result in:
```json
{
  "a":  1,
  "b":  [
      1,
      2
  ]      
}
```
whereas expected value is:
```json
{
  "a": 1,
  "b": [
    1,
    2
  ]
}
```