### PR TITLE
property.ValueType is NotExistsInObject after DefineProperty

### DIFF
--- a/NiL.JS/Core/JSValue.cs
+++ b/NiL.JS/Core/JSValue.cs
@@ -481,7 +481,7 @@ namespace NiL.JS.Core
                 throw new ArgumentException();
 
             property = DefineProperty(name);
-            if (property.ValueType < JSValueType.Undefined)
+            if (property.ValueType < JSValueType.NotExistsInObject)
                 throw new InvalidOperationException();
 
             property._valueType = JSValueType.Property;


### PR DESCRIPTION
Hello,

`property.ValueType < JSValueType.Undefined` is always `false`, so it should be `property.ValueType < JSValueType.NotExistsInObject` ?