### PR TITLE
Return a support for .NET Framework 4.0 and 4.5

### DIFF
--- a/NiL.JS/NiL.JS.csproj
+++ b/NiL.JS/NiL.JS.csproj
@@ -28,7 +28,6 @@
     </SccAuxPath>
     <SccProvider>
     </SccProvider>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Hello, Dmitry!

In NiL.JS version 2.5.1339 missing support for .NET Framework 4.0 and 4.5.