### PR TITLE
Add support of module evaluation

### DIFF
--- a/NiL.JS.NetCore/Script.cs
+++ b/NiL.JS.NetCore/Script.cs
@@ -62,7 +62,7 @@ namespace NiL.JS
             try
             {
                 context.Activate();
-                return Root.Evaluate(context);
+                return Root.Evaluate(context) ?? context._lastResult ?? JSValue.notExists;
             }
             finally
             {


### PR DESCRIPTION
Hello, Dmitry!

If run the following code in current version:

```csharp
using System;

using NiL.JS;
using NiL.JS.Core;

namespace TestModuleEvaluation
{
    class Program
    {
        static Program()
        {
            Module.ResolveModule += MyModuleResolver;
        }


        static void Main(string[] args)
        {
            var mainModule = new Module("main.js", @"import * as arithmetic from 'arithmetic.js';
arithmetic.add(678, 711);");
            JSValue resultValue = mainModule.Script.Evaluate(mainModule.Context);

            Console.WriteLine("result = {0}", resultValue.Value);
        }

        private static void MyModuleResolver(Module sender, ResolveModuleEventArgs e)
        {
            if (e.ModulePath == "/arithmetic.js")
            {
                e.Module = new Module(e.ModulePath, @"export function add(num1, num2) {
    return num1 + num2;
}");
            }
            else
            {
                throw new InvalidOperationException();
            }

            e.Module.Run();
        }
    }
}
```

Then the following error will occur:

```
System.NullReferenceException: Object reference not set to an instance of an object
```

The reason for this error is that the `Evaluate` method of `NiL.JS.Script` class always returns null. Accordingly, this PR corrects this error.

P.S.: I know that in modules need to use exports, but sometimes there are situations when need the module to work as a ordinary script.