### PR TITLE
Add the ability to specify a custom module path resolver

### DIFF
--- a/NiL.JS/ResolveModuleEventArgs.cs
+++ b/NiL.JS/ResolveModuleEventArgs.cs
@@ -10,7 +10,7 @@ namespace NiL.JS
 
     public class ResolveModuleEventArgs : EventArgs
     {
-        public string ModulePath { get; private set; }
+        public string ModulePath { get; set; }
         public Module Module { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Hello, Dmitry!

At the moment, logic of module path resolution is hard-coded in the `processPath` method of `Module` class, which is not very convenient (for example, now all paths are root). I propose to convert this method to a delegate of the `ResolveModuleHandler` type and add it first to the list of handlers.

To do this, do the following:

 1. Make a `ModulePath` property of `ResolveModuleEventArgs` class writable.
 2. Convert the `processPath` method to the `DefaultModulePathResolver` method.
 3. Rename the `DefaultModuleResolver` method to the `DefaultModuleCacheResolver` method.
 4. Register the `DefaultModulePathResolver` and `DefaultModuleCacheResolver` methods as default handlers.