### PR TITLE
Make Array(JSValue[]) ctor public

### DIFF
--- a/NiL.JS/BaseLibrary/Array.cs
+++ b/NiL.JS/BaseLibrary/Array.cs
@@ -62,7 +62,8 @@ namespace NiL.JS.BaseLibrary
                 _data[(int)((uint)length - 1)] = null;
         }
 
-        internal Array(JSValue[] data)
+        [DoNotEnumerate]
+        public Array(JSValue[] data)
         {
             _oValue = this;
             _valueType = JSValueType.Object;

--- a/NiL.JS/BaseLibrary/Date.cs
+++ b/NiL.JS/BaseLibrary/Date.cs
@@ -70,6 +70,13 @@ namespace NiL.JS.BaseLibrary
         }
 
         [DoNotEnumerate]
+        public Date(DateTimeOffset dateTimeOffset)
+        {
+            _time = dateTimeOffset.UtcTicks / 10000;
+            _timeZoneOffset = dateTimeOffset.Offset.Ticks / 10000;
+        }
+
+        [DoNotEnumerate]
         [ArgumentsCount(7)]
         public Date(Arguments args)
         {

--- a/NiL.JS/BaseLibrary/Date.cs
+++ b/NiL.JS/BaseLibrary/Date.cs
@@ -70,13 +70,6 @@ namespace NiL.JS.BaseLibrary
         }
 
         [DoNotEnumerate]
-        public Date(DateTimeOffset dateTimeOffset)
-        {
-            _time = dateTimeOffset.UtcTicks / 10000;
-            _timeZoneOffset = dateTimeOffset.Offset.Ticks / 10000;
-        }
-
-        [DoNotEnumerate]
         [ArgumentsCount(7)]
         public Date(Arguments args)
         {


### PR DESCRIPTION
This constructor is much faster than its IEnumerable equivalent because items are not cloned on insertion.


<details>
<summary>Benchmark.Net code</summary>

```
using BenchmarkDotNet.Attributes;
using NiL.JS;
using NiL.JS.BaseLibrary;
using NiL.JS.Core;
using System;
using System.Linq;

namespace ConsoleApp1
{
    [MemoryDiagnoser]
    public class EvalBenchmarks
    {

        private readonly GlobalContext _globalContext;
        private Script _parsedScript;
        private Context _context;

        public static DateTimeOffset Now { get; set; } = DateTimeOffset.Now;

        [Params(0,1,2)]
        public int ArrayCtorMethod { get; set; }

        public string _script;

        public EvalBenchmarks()
        {
            _globalContext = new GlobalContext();

            Date.CurrentTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Romance Standard Time");
        }

        [GlobalSetup]
        public void GlobalSetup()
        {
            _script = @"
const result = from().get(" + ArrayCtorMethod +  @");
//const map = new Map();
for (const item of result.data) {
    //const hour = item.date.getHours();
    //const x = map.get(item.id);
}";

            _parsedScript = Script.Parse(_script);

            var items = new QueryResultObject[1000];

            for (var i = 0; i < items.Length; i++)
            {
                items[i] = new QueryResultObject();
            }

            _context = new Context(_globalContext);
            _context.DefineVariable("items").Assign(new NiL.JS.BaseLibrary.Array(items));

            _context.DefineVariable("from").Assign(JSValue.Marshal(new Func<FromResultObject>(From)));

            FromResultObject From()
            {
                return new FromResultObject();
            }
        }

        [Benchmark]
        public void ContextEval()
        {
            _context.Eval(_script);
        }

        [Benchmark]
        public void ScriptEvaluate()
        {
            _parsedScript.Evaluate(_context);
        }

        public class FromResultObject
        {
            public JSValue get(int method)
            {
                var result = new QueryResultObject();
                var data = new DataObject[10000];

                for (var i = 0; i < data.Length; i++)
                {
                    data[i] = new DataObject() { id = i, date = new Date(Now) };
                }

                if (method == 0)
                {
                    result.data = new NiL.JS.BaseLibrary.Array(data.Select(JSValue.Marshal).ToArray().AsEnumerable());
                }
                else if (method == 1)
                {
                    result.data = new NiL.JS.BaseLibrary.Array(data.Select(JSValue.Marshal).ToArray());
                }
                else if (method == 2)
                {
                    result.data = new NiL.JS.BaseLibrary.Array(data.Select(JSValue.Wrap).ToArray());
                }
                return JSValue.Marshal(result);
            }
        }

        public class QueryResultObject
        {
            public NiL.JS.BaseLibrary.Array data { get; set; }
        }

        public class DataObject
        {
            public Date date { get; set; }
            public int id { get; set; }
        }
    }
}

```

</details>

![image](https://user-images.githubusercontent.com/2112306/65948922-7776f980-e43b-11e9-8e83-d4d3dcef5629.png)

Method 0: Using current IEnumerable ctor
Method 1: Using JSValue[] ctor
Method 2: Using JSValue[] ctor but with JSValue.Wrap instead of Marshal.