### PR TITLE
Sign assemblies with a strong name

### DIFF
--- a/NiL.JS/NiL.JS.csproj
+++ b/NiL.JS/NiL.JS.csproj
@@ -10,6 +10,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
     <AssemblyName>NiL.JS</AssemblyName>
+    <AssemblyOriginatorKeyFile>keys.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>NiL.JS</PackageId>
     <PackageTags>js;javascript;java;script;ecma;ecmascript;es2015;v8;niljs;nil;nilproject</PackageTags>
     <PackageIconUrl>https://github.com/nilproject/NiL.JS/blob/develop/nil.js%20logo%20small.png</PackageIconUrl>


### PR DESCRIPTION
Hello, Dmitry!

Assemblies in latest version of the package are unsigned.

To make this PR working, you need to add the `keys.snk` file to the `NiL.JS` directory.