### PR TITLE
fix: do not double run module on import

### DIFF
--- a/NiL.JS/Module.cs
+++ b/NiL.JS/Module.cs
@@ -173,7 +173,9 @@ namespace NiL.JS
         /// </summary>
         public void Run()
         {
+            EvaluationState = ModuleEvaluationState.Evaluating;
             Script.Evaluate(Context);
+            EvaluationState = ModuleEvaluationState.Evaluated;
         }
 
         /// <summary>
@@ -194,9 +196,7 @@ namespace NiL.JS
 
             try
             {
-                EvaluationState = ModuleEvaluationState.Evaluating;
                 Run();
-                EvaluationState = ModuleEvaluationState.Evaluated;
             }
             catch
             {


### PR DESCRIPTION
This will fix a duplicate module evaluation at

https://github.com/nilproject/NiL.JS/blob/38c8f2dde40be56a8b62cc12cf7eee769fc30393/NiL.JS/Module.cs#L231-L235

ref #220 