### PR TITLE
#226 Made random thread safe

### DIFF
--- a/NiL.JS/BaseLibrary/Math.cs
+++ b/NiL.JS/BaseLibrary/Math.cs
@@ -2,13 +2,28 @@ using System;
 using NiL.JS.Core.Interop;
 using NiL.JS.Core;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace NiL.JS.BaseLibrary
 {
     public static class Math
     {
+        /// <summary>
+        /// Seed value for random instance
+        /// </summary>
         [Hidden]
-        internal readonly static Random randomInstance = new Random((int)DateTime.Now.Ticks);
+        private static int _randomSeed = Environment.TickCount;
+        
+        /// <summary>
+        /// Random instance 
+        /// </summary>
+        /// <remarks>
+        /// ThreadLocal allows us to make a different version of static variable for each thread.
+        /// Since we usually use a thread pool redundant instances would not be created.
+        /// ThreadLocal allows us not to do lock, while being faster and thread-safe
+        /// </remarks>
+        [Hidden]
+        internal static readonly ThreadLocal<Random> randomInstance = new ThreadLocal<Random>(() => new Random(Interlocked.Increment(ref _randomSeed)));
 
         [DoNotDelete]
         [DoNotEnumerate]
@@ -559,7 +574,7 @@ namespace NiL.JS.BaseLibrary
         [DoNotDelete]
         public static JSValue random()
         {
-            return randomInstance.NextDouble();
+            return randomInstance.Value.NextDouble();
         }
 
         [DoNotDelete]

--- a/NiL.JS/NiL.JS.csproj
+++ b/NiL.JS/NiL.JS.csproj
@@ -10,9 +10,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
     <AssemblyName>NiL.JS</AssemblyName>
-    <AssemblyOriginatorKeyFile>keys.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">false</PublicSign>
     <PackageId>NiL.JS</PackageId>
     <PackageTags>js;javascript;java;script;ecma;ecmascript;es2015;v8;niljs;nil;nilproject</PackageTags>
     <PackageIconUrl>https://github.com/nilproject/NiL.JS/blob/develop/nil.js%20logo%20small.png</PackageIconUrl>

--- a/NiL.JS/NiL.JS.csproj
+++ b/NiL.JS/NiL.JS.csproj
@@ -10,7 +10,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
     <AssemblyName>NiL.JS</AssemblyName>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">false</PublicSign>
+    <AssemblyOriginatorKeyFile>keys.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>NiL.JS</PackageId>
     <PackageTags>js;javascript;java;script;ecma;ecmascript;es2015;v8;niljs;nil;nilproject</PackageTags>
     <PackageIconUrl>https://github.com/nilproject/NiL.JS/blob/develop/nil.js%20logo%20small.png</PackageIconUrl>


### PR DESCRIPTION
This PR fixes #226 

I made random a ThreadLocal. 

ThreadLocal allows us to make a different version of static variables for each thread. Since we usually use a thread pool redundant instances would not be created.  ThreadLocal allows us not to do lock while being faster and thread-safe