### PR TITLE
Fix .Net Core Task<> conversion

### DIFF
--- a/NiL.JS/Core/GlobalContext.cs
+++ b/NiL.JS/Core/GlobalContext.cs
@@ -473,9 +473,15 @@ namespace NiL.JS.Core
                     else if (value is Task)
                     {
                         Task<JSValue> result;
+#if NETCORE
+                        if (value.GetType().GetTypeInfo().IsGenericType)
+                        {
+                            result = new Task<JSValue>(() => ProxyValue(value.GetType().GetProperty("Result").GetValue(value)));
+#else
                         if (value.GetType().GetTypeInfo().IsGenericType && typeof(Task<>).IsAssignableFrom(value.GetType().GetGenericTypeDefinition()))
                         {
                             result = new Task<JSValue>(() => ProxyValue(value.GetType().GetMethod("get_Result", new Type[0]).Invoke(value, null)));
+#endif
                         }
                         else
                         {


### PR DESCRIPTION
Tested on .Net Core 3.1
Not all `Task<>` is `Task<>` at runtime, it might be `System.Runtime.CompilerServices.AsyncTaskMethodBuilder1+AsyncStateMachineBox1[TResult,TStateMachine]`, which is a struct not `Task<>`