### PR TITLE
Fixed property name discrepancy

### DIFF
--- a/NiL.JS/BaseLibrary/Promise.cs
+++ b/NiL.JS/BaseLibrary/Promise.cs
@@ -41,8 +41,12 @@ namespace NiL.JS.BaseLibrary
         [Hidden]
         public Task<JSValue> Task => _task;
 
+        [Obsolete]
         [Hidden]
-        public bool Complited
+        public bool Complited => Completed;
+
+        [Hidden]
+        public bool Completed
         {
             get { return _task.IsCompleted; }
         }


### PR DESCRIPTION
Corrected property name spelling from "Complited" to "Completed."  I've left the original property in place but marked it obsolete to maintain compatibility with existing code.

Apologies if the naming mismatch was intentional.