### PR TITLE
Improvements for callstack

### DIFF
--- a/Examples/0. Run script/Get callstack.cs
+++ b/Examples/0. Run script/Get callstack.cs
@@ -45,8 +45,9 @@ catch (e) {
 ";
         public override void Run()
         {
-
-            Script.Parse(_code).Evaluate(new NiL.JS.Core.Context());
+           
+            Module main = new Module("main.js", _code);
+            main.Run();
         }
     }
 }

--- a/Examples/0. Run script/Get callstack.cs
+++ b/Examples/0. Run script/Get callstack.cs
@@ -1,0 +1,52 @@
+﻿using ExamplesFramework;
+using NiL.JS;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Examples.Run_script
+{
+    [Level(0)]
+    public sealed class Get_stack : Example
+    {
+        private static readonly string _code = @"
+
+function test1() {
+    test2();
+}
+
+function test2() {
+    test3();
+}
+
+function test3() {
+    test4();
+}
+
+function test4() {
+    var x = new MissingThing(1, 2, 3);
+}
+
+try {
+    test1();
+}
+catch (e) {
+    try {
+        console.log(e.toString());
+        var x = new MissingThing(1, 1, 1);
+    }
+    catch (ex) {
+        console.log(ex.toString());
+    }
+}
+
+";
+        public override void Run()
+        {
+
+            Script.Parse(_code).Evaluate(new NiL.JS.Core.Context());
+        }
+    }
+}

--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -45,6 +45,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="0. Run script\Get callstack.cs" />
     <Compile Include="1. Using modules\Execution time limit.cs" />
     <Compile Include="1. Using modules\Custom module resolver.cs" />
     <Compile Include="3. Get values from JavaScript environment\Determine type of value.cs" />

--- a/NiL.JS/BaseLibrary/Error.cs
+++ b/NiL.JS/BaseLibrary/Error.cs
@@ -75,7 +75,7 @@ namespace NiL.JS.BaseLibrary
                 if (context != null)
                 {
                     var line = FromTextPosition(context.RootContext.Code, context.CodeNode.Position);
-                    res.Append("    at ").AppendLine($"{context._owner.name ?? "<anonymous method>"}({context._module?.FilePath ?? "<anonymous>"}:{line})");
+                    res.Append("    at ").AppendLine($"{context._owner?.name ?? "<anonymous method>"}({context._module?.FilePath ?? "<anonymous>"}:{line})");
                 }
             }
             callstack = Context.CurrentGlobalContext.ProxyValue(res.ToString());

--- a/NiL.JS/Core/Context.cs
+++ b/NiL.JS/Core/Context.cs
@@ -137,6 +137,8 @@ namespace NiL.JS.Core
                 return result;
             }
         }
+        public string Code { get; set; }
+        public CodeNode CodeNode { get; set; }
 
         public static GlobalContext CurrentGlobalContext => (CurrentContext ?? _DefaultGlobalContext).GlobalContext;
 

--- a/NiL.JS/Script.cs
+++ b/NiL.JS/Script.cs
@@ -65,6 +65,7 @@ namespace NiL.JS
             try
             {
                 context.Activate();
+                context.Code = Code;
                 return Root.Evaluate(context) ?? context._lastResult ?? JSValue.notExists;
             }
             finally

--- a/NiL.JS/Statements/CodeBlock.cs
+++ b/NiL.JS/Statements/CodeBlock.cs
@@ -349,7 +349,11 @@ namespace NiL.JS.Statements
             {
                 if (context._debugging)
                     context.raiseDebugger(_lines[i]);
-                var t = ls[i].Evaluate(context);
+
+                var node = ls[i];
+                context.CodeNode = node;
+                JSValue t = node.Evaluate(context);
+
                 if (t != null)
                     context._lastResult = t;
 #if DEBUG && !(PORTABLE || NETCORE)

--- a/NiL.JS/Statements/TryCatch.cs
+++ b/NiL.JS/Statements/TryCatch.cs
@@ -228,6 +228,7 @@ namespace NiL.JS.Statements
                     catchContext._executionMode = c._executionMode;
                     catchContext._executionInfo = c._executionInfo;
                     catchContext.Activate();
+                    catchContext.CodeNode = catchBody;
                     catchContext._lastResult = catchBody.Evaluate(catchContext) ?? catchContext._lastResult;
                 }
                 finally

--- a/NiL.JS/Statements/TryCatch.cs
+++ b/NiL.JS/Statements/TryCatch.cs
@@ -228,7 +228,6 @@ namespace NiL.JS.Statements
                     catchContext._executionMode = c._executionMode;
                     catchContext._executionInfo = c._executionInfo;
                     catchContext.Activate();
-                    catchContext.CodeNode = catchBody;
                     catchContext._lastResult = catchBody.Evaluate(catchContext) ?? catchContext._lastResult;
                 }
                 finally


### PR DESCRIPTION
like this
```
    string _code = @"

function test1() {
    test2();
}

function test2() {
    test3();
}

function test3() {
    test4();
}

function test4() {
    var x = new MissingThing(1, 2, 3);
}

try {
    test1();
}
catch (e) {
    console.log(e.toString());
}

";
    Script.Parse(_code).Evaluate(new NiL.JS.Core.Context());

```
output:

```
ReferenceError: Variable "MissingThing" is not defined
    at var x = new MissingThing(1, 2, 3)
    at test4(<anonymous>:16)
    at test3(<anonymous>:12)
    at test2(<anonymous>:8)
    at test1(<anonymous>:4)
    at anonymous(<anonymous>:19)
```
