### PR TITLE
Improvements for callstack

### DIFF
--- a/Examples/0. Run script/Get callstack.cs
+++ b/Examples/0. Run script/Get callstack.cs
@@ -1,0 +1,76 @@
+﻿using ExamplesFramework;
+using NiL.JS;
+using NiL.JS.Core;
+using System;
+
+namespace Examples.Run_script
+{
+    [Level(0)]
+    public sealed class Get_stack : Example
+    {
+        private static readonly string _code = @"
+try{
+var text = `
+test callstack
+MissingThing${missingThing}
+`;
+}
+catch(e){
+console.log(e.toString());
+}
+
+try{
+ClrTest();
+}
+catch(e){
+console.log(e.toString());
+}
+
+
+try{
+import Test from 'test';
+
+new Test().test();
+}
+catch(e){
+console.log(e.toString());
+}
+";
+        public override void Run()
+        {
+            var mainModule = new Module("main.js", _code);
+            mainModule.ModuleResolversChain.Add(new MyTestModuleResolver());
+            mainModule.Context.DefineVariable("ClrTest").Assign(JSValue.Marshal(new Action(() => { throw new Exception("clr error"); })));
+            mainModule.Run();
+        }
+
+        public sealed class MyTestModuleResolver : CachedModuleResolverBase
+        {
+            public override bool TryGetModule(ModuleRequest moduleRequest, out Module result)
+            {
+                if (moduleRequest.AbsolutePath == "/test.js")
+                {
+                    result = new Module(moduleRequest.AbsolutePath, @"
+class Test{
+    test() {
+        this.test2();
+    }
+
+    test1() {
+        this.test3();
+    }
+    test2() {
+        var x = new MissingThing(1, 2, 3);
+    }
+}
+export default Test;
+");
+                    return true;
+                }
+
+                result = null;
+                return false;
+            }
+        }
+    }
+}

--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -45,6 +45,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="0. Run script\Get callstack.cs" />
     <Compile Include="1. Using modules\Execution time limit.cs" />
     <Compile Include="1. Using modules\Custom module resolver.cs" />
     <Compile Include="3. Get values from JavaScript environment\Determine type of value.cs" />

--- a/NiL.JS/Core/Context.cs
+++ b/NiL.JS/Core/Context.cs
@@ -66,7 +66,7 @@ namespace NiL.JS.Core
         [ThreadStatic]
         internal static List<Context> currentContextStack;
 
-        internal static List<Context> GetCurrectContextStack()
+        internal static List<Context> GetCurrentContextStack()
         {
             if (currentContextStack == null)
                 currentContextStack = new List<Context> { DefaultGlobalContext };
@@ -78,7 +78,7 @@ namespace NiL.JS.Core
         {
             get
             {
-                var stack = GetCurrectContextStack();
+                var stack = GetCurrentContextStack();
                 if (stack == null || stack.Count == 0)
                     return null;
 
@@ -138,6 +138,11 @@ namespace NiL.JS.Core
             }
         }
 
+        internal string _code { get; set; }
+
+        internal int _currentPosition { get; set; }
+
+
         public static GlobalContext CurrentGlobalContext => (CurrentContext ?? _DefaultGlobalContext).GlobalContext;
 
         public JSValue ThisBind
@@ -180,7 +185,7 @@ namespace NiL.JS.Core
         {
             get
             {
-                return GetCurrectContextStack().Contains(this);
+                return GetCurrentContextStack().Contains(this);
             }
         }
 
@@ -293,7 +298,7 @@ namespace NiL.JS.Core
             if (function == null)
                 return null;
 
-            var stack = GetCurrectContextStack();
+            var stack = GetCurrentContextStack();
 
             for (var i = stack.Count; i-- > 0;)
             {
@@ -531,7 +536,7 @@ namespace NiL.JS.Core
              */
 
             var mainFunctionContext = this;
-            var stack = GetCurrectContextStack();
+            var stack = GetCurrentContextStack();
             while (stack != null
                 && stack.Count > 1
                 && stack[stack.Count - 2] == mainFunctionContext._parent

--- a/NiL.JS/Core/JSException.cs
+++ b/NiL.JS/Core/JSException.cs
@@ -20,6 +20,7 @@ namespace NiL.JS.Core
         public JSException(Error data)
         {
             Error = Context.CurrentGlobalContext.ProxyValue(data);
+            data.MakeCallStack();
         }
 
         public JSException(Error data, CodeNode exceptionMaker, string code)
@@ -30,23 +31,27 @@ namespace NiL.JS.Core
             if (code != null) {
                 CodeCoordinates = CodeCoordinates.FromTextPosition(code, exceptionMaker.Position, exceptionMaker.Length);
             }
+            data.MakeCallStack(exceptionMaker);
         }
 
         public JSException(JSValue data)
         {
             Error = data;
+            (data.Value as Error)?.MakeCallStack();
         }
 
         public JSException(JSValue data, Exception innerException)
             : base("External error", innerException)
         {
             Error = data;
+            (data.Value as Error)?.MakeCallStack();
         }
 
         public JSException(Error avatar, Exception innerException)
             : base("", innerException)
         {
             Error = Context.CurrentGlobalContext.ProxyValue(avatar);
+            avatar.MakeCallStack();
         }
 
         public override string Message

--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -30,15 +30,25 @@ namespace NiL.JS.Core
 
     public sealed class CodeCoordinates
     {
+        public string Code { get; private set; }
         public int Line { get; private set; }
         public int Column { get; private set; }
         public int Length { get; private set; }
 
         public CodeCoordinates(int line, int column, int length)
         {
+            Code = string.Empty;
             Line = line;
             Column = column;
             Length = length;
+        }
+
+        public CodeCoordinates(string code, int line, int column)
+        {
+            Code = code;
+            Line = line;
+            Column = column;
+            Length = -1;
         }
 
         public override string ToString()
@@ -82,6 +92,63 @@ namespace NiL.JS.Core
             }
 
             return new CodeCoordinates(line, column, length);
+        }
+
+        public static CodeCoordinates FromTextPosition(string text, int position)
+        {
+            if (text == null)
+                throw new ArgumentNullException("text");
+
+            if (position < 0 || position >= text.Length)
+                throw new ArgumentOutOfRangeException("position");
+
+
+            int line = 1;
+            int column = 1;
+            for (int i = 0; i < position; i++)
+            {
+                if (text[i] == '\n')
+                {
+                    column = 0;
+                    line++;
+                    if (text.Length > i + 1 && text[i + 1] == '\r')
+                        i++;
+                }
+                else if (text[i] == '\r')
+                {
+                    column = 0;
+                    line++;
+                    if (text.Length > i + 1 && text[i + 1] == '\n')
+                        i++;
+                }
+                column++;
+            }
+
+            int startPosition = 0;
+
+            for (int i = position; i >= 0; i--)
+            {
+                if (text[i] == '\n' || text[i] == '\r')
+                {
+                    startPosition = i + 1;
+                    break;
+                }
+            }
+
+            int endPosition = text.Length;
+
+            for (int i = position; i < text.Length; i++)
+            {
+                if (text[i] == '\n' || text[i] == '\r')
+                {
+                    endPosition = i;
+                    break;
+                }
+            }
+
+            string code = text.Substring(startPosition, endPosition - startPosition).Trim();
+
+            return new CodeCoordinates(code, line, column);
         }
     }
 
@@ -210,36 +277,36 @@ namespace NiL.JS.Core
                 {
                     case JSValueType.Boolean:
                     case JSValueType.Integer:
-                    {
-                        return arg._iValue;
-                    }
+                        {
+                            return arg._iValue;
+                        }
                     case JSValueType.Double:
-                    {
-                        return arg._dValue;
-                    }
+                        {
+                            return arg._dValue;
+                        }
                     case JSValueType.String:
-                    {
-                        double x = double.NaN;
-                        int ix = 0;
-                        string s = (arg._oValue.ToString());
-                        if (s.Length > 0 && (Tools.IsWhiteSpace(s[0]) || Tools.IsWhiteSpace(s[s.Length - 1])))
-                            s = s.Trim(Tools.TrimChars);
+                        {
+                            double x = double.NaN;
+                            int ix = 0;
+                            string s = (arg._oValue.ToString());
+                            if (s.Length > 0 && (Tools.IsWhiteSpace(s[0]) || Tools.IsWhiteSpace(s[s.Length - 1])))
+                                s = s.Trim(Tools.TrimChars);
 
-                        if (Tools.ParseNumber(s, ref ix, out x, 0, ParseNumberOptions.AllowFloat | ParseNumberOptions.AllowAutoRadix) && ix < s.Length)
-                            return double.NaN;
+                            if (Tools.ParseNumber(s, ref ix, out x, 0, ParseNumberOptions.AllowFloat | ParseNumberOptions.AllowAutoRadix) && ix < s.Length)
+                                return double.NaN;
 
-                        return x;
-                    }
+                            return x;
+                        }
                     case JSValueType.Date:
                     case JSValueType.Function:
                     case JSValueType.Object:
-                    {
-                        if (arg._oValue == null)
-                            return 0;
-                        arg = arg.ToPrimitiveValue_Value_String();
-                        break;
-                        //return JSObjectToDouble(arg);
-                    }
+                        {
+                            if (arg._oValue == null)
+                                return 0;
+                            arg = arg.ToPrimitiveValue_Value_String();
+                            break;
+                            //return JSObjectToDouble(arg);
+                        }
                     case JSValueType.NotExists:
                     case JSValueType.Undefined:
                     case JSValueType.NotExistsInObject:
@@ -318,46 +385,46 @@ namespace NiL.JS.Core
             {
                 case JSValueType.Boolean:
                 case JSValueType.Integer:
-                {
-                    return value._iValue;
-                }
+                    {
+                        return value._iValue;
+                    }
                 case JSValueType.Double:
-                {
-                    if (double.IsNaN(value._dValue))
-                        return nan;
+                    {
+                        if (double.IsNaN(value._dValue))
+                            return nan;
 
-                    if (double.IsInfinity(value._dValue))
-                        return alternateInfinity ? double.IsPositiveInfinity(value._dValue) ? int.MaxValue : int.MinValue : 0;
+                        if (double.IsInfinity(value._dValue))
+                            return alternateInfinity ? double.IsPositiveInfinity(value._dValue) ? int.MaxValue : int.MinValue : 0;
 
-                    return (int)(long)value._dValue;
-                }
+                        return (int)(long)value._dValue;
+                    }
                 case JSValueType.String:
-                {
-                    double x = 0;
-                    int ix = 0;
-                    string s = (value._oValue.ToString()).Trim();
+                    {
+                        double x = 0;
+                        int ix = 0;
+                        string s = (value._oValue.ToString()).Trim();
 
-                    if (!Tools.ParseNumber(s, ref ix, out x, 0, ParseNumberOptions.AllowAutoRadix | ParseNumberOptions.AllowFloat) || ix < s.Length)
-                        return 0;
+                        if (!Tools.ParseNumber(s, ref ix, out x, 0, ParseNumberOptions.AllowAutoRadix | ParseNumberOptions.AllowFloat) || ix < s.Length)
+                            return 0;
 
-                    if (double.IsNaN(x))
-                        return nan;
+                        if (double.IsNaN(x))
+                            return nan;
 
-                    if (double.IsInfinity(x))
-                        return alternateInfinity ? double.IsPositiveInfinity(x) ? int.MaxValue : int.MinValue : 0;
+                        if (double.IsInfinity(x))
+                            return alternateInfinity ? double.IsPositiveInfinity(x) ? int.MaxValue : int.MinValue : 0;
 
-                    return (int)x;
-                }
+                        return (int)x;
+                    }
                 case JSValueType.Date:
                 case JSValueType.Function:
                 case JSValueType.Object:
-                {
-                    if (value._oValue == null)
-                        return @null;
+                    {
+                        if (value._oValue == null)
+                            return @null;
 
-                    value = value.ToPrimitiveValue_Value_String();
-                    return JSObjectToInt32(value, 0, 0, 0, true);
-                }
+                        value = value.ToPrimitiveValue_Value_String();
+                        return JSObjectToInt32(value, 0, 0, 0, true);
+                    }
                 case JSValueType.NotExists:
                 case JSValueType.Undefined:
                 case JSValueType.NotExistsInObject:
@@ -412,39 +479,39 @@ namespace NiL.JS.Core
             {
                 case JSValueType.Boolean:
                 case JSValueType.Integer:
-                {
-                    return r._iValue;
-                }
+                    {
+                        return r._iValue;
+                    }
                 case JSValueType.Double:
-                {
-                    if (double.IsNaN(r._dValue))
-                        return 0;
-                    if (double.IsInfinity(r._dValue))
-                        return alternateInfinity ? double.IsPositiveInfinity(r._dValue) ? long.MaxValue : long.MinValue : 0;
-                    return (long)r._dValue;
-                }
+                    {
+                        if (double.IsNaN(r._dValue))
+                            return 0;
+                        if (double.IsInfinity(r._dValue))
+                            return alternateInfinity ? double.IsPositiveInfinity(r._dValue) ? long.MaxValue : long.MinValue : 0;
+                        return (long)r._dValue;
+                    }
                 case JSValueType.String:
-                {
-                    double x = 0;
-                    int ix = 0;
-                    string s = (r._oValue.ToString()).Trim();
-                    if (!Tools.ParseNumber(s, ref ix, out x, 0, ParseNumberOptions.AllowAutoRadix | ParseNumberOptions.AllowFloat) || ix < s.Length)
-                        return 0;
-                    if (double.IsNaN(x))
-                        return 0;
-                    if (double.IsInfinity(x))
-                        return alternateInfinity ? double.IsPositiveInfinity(x) ? long.MaxValue : long.MinValue : 0;
-                    return (long)x;
-                }
+                    {
+                        double x = 0;
+                        int ix = 0;
+                        string s = (r._oValue.ToString()).Trim();
+                        if (!Tools.ParseNumber(s, ref ix, out x, 0, ParseNumberOptions.AllowAutoRadix | ParseNumberOptions.AllowFloat) || ix < s.Length)
+                            return 0;
+                        if (double.IsNaN(x))
+                            return 0;
+                        if (double.IsInfinity(x))
+                            return alternateInfinity ? double.IsPositiveInfinity(x) ? long.MaxValue : long.MinValue : 0;
+                        return (long)x;
+                    }
                 case JSValueType.Date:
                 case JSValueType.Function:
                 case JSValueType.Object:
-                {
-                    if (r._oValue == null)
-                        return nullOrUndefined;
-                    r = r.ToPrimitiveValue_Value_String();
-                    return JSObjectToInt64(r, nullOrUndefined, alternateInfinity);
-                }
+                    {
+                        if (r._oValue == null)
+                            return nullOrUndefined;
+                        r = r.ToPrimitiveValue_Value_String();
+                        return JSObjectToInt64(r, nullOrUndefined, alternateInfinity);
+                    }
                 case JSValueType.NotExists:
                 case JSValueType.Undefined:
                 case JSValueType.NotExistsInObject:
@@ -474,46 +541,46 @@ namespace NiL.JS.Core
             switch (arg._valueType)
             {
                 case JSValueType.Boolean:
-                {
-                    result._valueType = JSValueType.Integer;
-                    result._iValue = arg._iValue;
-                    return result;
-                }
+                    {
+                        result._valueType = JSValueType.Integer;
+                        result._iValue = arg._iValue;
+                        return result;
+                    }
                 case JSValueType.Integer:
                 case JSValueType.Double:
                     return arg;
                 case JSValueType.String:
-                {
-                    double x = 0;
-                    int ix = 0;
-                    string s = (arg._oValue.ToString()).Trim(TrimChars);
-                    if (!Tools.ParseNumber(s, ref ix, out x, ParseNumberOptions.Default & ~ParseNumberOptions.ProcessOctalLiteralsOldSyntax) || ix < s.Length)
-                        x = double.NaN;
-                    result._valueType = JSValueType.Double;
-                    result._dValue = x;
-                    return result;
-                }
+                    {
+                        double x = 0;
+                        int ix = 0;
+                        string s = (arg._oValue.ToString()).Trim(TrimChars);
+                        if (!Tools.ParseNumber(s, ref ix, out x, ParseNumberOptions.Default & ~ParseNumberOptions.ProcessOctalLiteralsOldSyntax) || ix < s.Length)
+                            x = double.NaN;
+                        result._valueType = JSValueType.Double;
+                        result._dValue = x;
+                        return result;
+                    }
                 case JSValueType.Date:
                 case JSValueType.Function:
                 case JSValueType.Object:
-                {
-                    if (arg._oValue == null)
                     {
-                        result._valueType = JSValueType.Integer;
-                        result._iValue = 0;
-                        return result;
+                        if (arg._oValue == null)
+                        {
+                            result._valueType = JSValueType.Integer;
+                            result._iValue = 0;
+                            return result;
+                        }
+                        arg = arg.ToPrimitiveValue_Value_String();
+                        return JSObjectToNumber(arg);
                     }
-                    arg = arg.ToPrimitiveValue_Value_String();
-                    return JSObjectToNumber(arg);
-                }
                 case JSValueType.NotExists:
                 case JSValueType.Undefined:
                 case JSValueType.NotExistsInObject:
-                {
-                    result._valueType = JSValueType.Double;
-                    result._dValue = double.NaN;
-                    return result;
-                }
+                    {
+                        result._valueType = JSValueType.Double;
+                        result._dValue = double.NaN;
+                        return result;
+                    }
                 default:
                     throw new NotImplementedException();
             }
@@ -534,208 +601,208 @@ namespace NiL.JS.Core
             switch (jsobj._valueType)
             {
                 case JSValueType.Boolean:
-                {
-                    if (hightLoyalty)
                     {
-                        if (targetType == typeof(string))
-                            return jsobj._iValue != 0 ? JSBool.TrueString : JSBool.FalseString;
+                        if (hightLoyalty)
+                        {
+                            if (targetType == typeof(string))
+                                return jsobj._iValue != 0 ? JSBool.TrueString : JSBool.FalseString;
+                        }
+
+                        if (targetType == typeof(bool))
+                            return jsobj._iValue != 0;
+
+                        if (targetType == typeof(JSBool))
+                            return new JSBool(jsobj._iValue != 0);
+
+                        return null;
                     }
-
-                    if (targetType == typeof(bool))
-                        return jsobj._iValue != 0;
-
-                    if (targetType == typeof(JSBool))
-                        return new JSBool(jsobj._iValue != 0);
-
-                    return null;
-                }
                 case JSValueType.Double:
-                {
-                    if (hightLoyalty)
                     {
-                        if (targetType == typeof(byte))
-                            return (byte)jsobj._dValue;
-                        if (targetType == typeof(sbyte))
-                            return (sbyte)jsobj._dValue;
-                        if (targetType == typeof(ushort))
-                            return (ushort)jsobj._dValue;
-                        if (targetType == typeof(short))
-                            return (short)jsobj._dValue;
-                        if (targetType == typeof(int))
-                            return (int)jsobj._dValue;
-                        if (targetType == typeof(uint))
-                            return (uint)jsobj._dValue;
-                        if (targetType == typeof(long))
-                            return (long)jsobj._dValue;
-                        if (targetType == typeof(ulong))
-                            return (ulong)jsobj._dValue;
-                        if (targetType == typeof(decimal))
-                            return (decimal)jsobj._dValue;
-                        if (targetType == typeof(string))
-                            return DoubleToString(jsobj._dValue);
+                        if (hightLoyalty)
+                        {
+                            if (targetType == typeof(byte))
+                                return (byte)jsobj._dValue;
+                            if (targetType == typeof(sbyte))
+                                return (sbyte)jsobj._dValue;
+                            if (targetType == typeof(ushort))
+                                return (ushort)jsobj._dValue;
+                            if (targetType == typeof(short))
+                                return (short)jsobj._dValue;
+                            if (targetType == typeof(int))
+                                return (int)jsobj._dValue;
+                            if (targetType == typeof(uint))
+                                return (uint)jsobj._dValue;
+                            if (targetType == typeof(long))
+                                return (long)jsobj._dValue;
+                            if (targetType == typeof(ulong))
+                                return (ulong)jsobj._dValue;
+                            if (targetType == typeof(decimal))
+                                return (decimal)jsobj._dValue;
+                            if (targetType == typeof(string))
+                                return DoubleToString(jsobj._dValue);
 
-                        if (targetType.GetTypeInfo().IsEnum)
-                            return Enum.ToObject(targetType, (long)jsobj._dValue);
-                    }
-
-                    if (targetType == typeof(double))
-                        return (double)jsobj._dValue;
-                    if (targetType == typeof(float))
-                        return (float)jsobj._dValue;
-
-                    if (targetType == typeof(Number))
-                        return new Number(jsobj._dValue);
-
-                    return null;
-                }
-                case JSValueType.Integer:
-                {
-                    if (hightLoyalty)
-                    {
-                        if (targetType == typeof(string))
-                            return Int32ToString(jsobj._iValue);
-
-                        if (targetType == typeof(byte))
-                            return (byte)jsobj._iValue;
-                        if (targetType == typeof(sbyte))
-                            return (sbyte)jsobj._iValue;
-                        if (targetType == typeof(ushort))
-                            return (ushort)jsobj._iValue;
-                        if (targetType == typeof(short))
-                            return (short)jsobj._iValue;
-                    }
-
-                    if (targetType == typeof(int))
-                        return (int)jsobj._iValue;
-
-                    if (targetType == typeof(uint))
-                        return (uint)jsobj._iValue;
-                    if (targetType == typeof(long))
-                        return (long)jsobj._iValue;
-                    if (targetType == typeof(ulong))
-                        return (ulong)jsobj._iValue;
-                    if (targetType == typeof(double))
-                        return (double)jsobj._iValue;
-                    if (targetType == typeof(float))
-                        return (float)jsobj._iValue;
-                    if (targetType == typeof(decimal))
-                        return (decimal)jsobj._iValue;
-
-                    if (targetType == typeof(Number))
-                        return new Number(jsobj._iValue);
-
-                    if (targetType.GetTypeInfo().IsEnum)
-                        return Enum.ToObject(targetType, jsobj._iValue);
-
-                    return null;
-                }
-                case JSValueType.String:
-                {
-                    if (hightLoyalty)
-                    {
-                        if (targetType == typeof(byte))
-                            return (byte)JSObjectToInt32(jsobj);
-                        if (targetType == typeof(sbyte))
-                            return (sbyte)JSObjectToInt32(jsobj);
-                        if (targetType == typeof(short))
-                            return (short)JSObjectToInt32(jsobj);
-                        if (targetType == typeof(ushort))
-                            return (ushort)JSObjectToInt32(jsobj);
-                        if (targetType == typeof(int))
-                            return JSObjectToInt32(jsobj);
-                        if (targetType == typeof(uint))
-                            return (uint)JSObjectToInt64(jsobj);
-                        if (targetType == typeof(long))
-                            return JSObjectToInt64(jsobj);
-                        if (targetType == typeof(ulong))
-                            return (ulong)JSObjectToInt64(jsobj);
+                            if (targetType.GetTypeInfo().IsEnum)
+                                return Enum.ToObject(targetType, (long)jsobj._dValue);
+                        }
 
                         if (targetType == typeof(double))
-                        {
-                            if (jsobj.Value.ToString() == "NaN")
-                                return double.NaN;
-
-                            var r = JSObjectToDouble(jsobj);
-                            if (!double.IsNaN(r))
-                                return r;
-
-                            return null;
-                        }
-
+                            return (double)jsobj._dValue;
                         if (targetType == typeof(float))
-                        {
-                            var r = JSObjectToDouble(jsobj);
-                            if (!double.IsNaN(r))
-                                return (float)r;
+                            return (float)jsobj._dValue;
 
-                            return null;
+                        if (targetType == typeof(Number))
+                            return new Number(jsobj._dValue);
+
+                        return null;
+                    }
+                case JSValueType.Integer:
+                    {
+                        if (hightLoyalty)
+                        {
+                            if (targetType == typeof(string))
+                                return Int32ToString(jsobj._iValue);
+
+                            if (targetType == typeof(byte))
+                                return (byte)jsobj._iValue;
+                            if (targetType == typeof(sbyte))
+                                return (sbyte)jsobj._iValue;
+                            if (targetType == typeof(ushort))
+                                return (ushort)jsobj._iValue;
+                            if (targetType == typeof(short))
+                                return (short)jsobj._iValue;
                         }
 
+                        if (targetType == typeof(int))
+                            return (int)jsobj._iValue;
+
+                        if (targetType == typeof(uint))
+                            return (uint)jsobj._iValue;
+                        if (targetType == typeof(long))
+                            return (long)jsobj._iValue;
+                        if (targetType == typeof(ulong))
+                            return (ulong)jsobj._iValue;
+                        if (targetType == typeof(double))
+                            return (double)jsobj._iValue;
+                        if (targetType == typeof(float))
+                            return (float)jsobj._iValue;
                         if (targetType == typeof(decimal))
-                        {
-                            var r = JSObjectToDouble(jsobj);
-                            if (!double.IsNaN(r))
-                                return (decimal)r;
+                            return (decimal)jsobj._iValue;
 
-                            return null;
-                        }
+                        if (targetType == typeof(Number))
+                            return new Number(jsobj._iValue);
 
                         if (targetType.GetTypeInfo().IsEnum)
+                            return Enum.ToObject(targetType, jsobj._iValue);
+
+                        return null;
+                    }
+                case JSValueType.String:
+                    {
+                        if (hightLoyalty)
                         {
-                            try
+                            if (targetType == typeof(byte))
+                                return (byte)JSObjectToInt32(jsobj);
+                            if (targetType == typeof(sbyte))
+                                return (sbyte)JSObjectToInt32(jsobj);
+                            if (targetType == typeof(short))
+                                return (short)JSObjectToInt32(jsobj);
+                            if (targetType == typeof(ushort))
+                                return (ushort)JSObjectToInt32(jsobj);
+                            if (targetType == typeof(int))
+                                return JSObjectToInt32(jsobj);
+                            if (targetType == typeof(uint))
+                                return (uint)JSObjectToInt64(jsobj);
+                            if (targetType == typeof(long))
+                                return JSObjectToInt64(jsobj);
+                            if (targetType == typeof(ulong))
+                                return (ulong)JSObjectToInt64(jsobj);
+
+                            if (targetType == typeof(double))
                             {
-                                return Enum.Parse(targetType, jsobj.Value.ToString());
-                            }
-                            catch
-                            {
+                                if (jsobj.Value.ToString() == "NaN")
+                                    return double.NaN;
+
+                                var r = JSObjectToDouble(jsobj);
+                                if (!double.IsNaN(r))
+                                    return r;
+
                                 return null;
                             }
+
+                            if (targetType == typeof(float))
+                            {
+                                var r = JSObjectToDouble(jsobj);
+                                if (!double.IsNaN(r))
+                                    return (float)r;
+
+                                return null;
+                            }
+
+                            if (targetType == typeof(decimal))
+                            {
+                                var r = JSObjectToDouble(jsobj);
+                                if (!double.IsNaN(r))
+                                    return (decimal)r;
+
+                                return null;
+                            }
+
+                            if (targetType.GetTypeInfo().IsEnum)
+                            {
+                                try
+                                {
+                                    return Enum.Parse(targetType, jsobj.Value.ToString());
+                                }
+                                catch
+                                {
+                                    return null;
+                                }
+                            }
                         }
-                    }
 
-                    if (targetType == typeof(string))
-                        return jsobj.Value.ToString();
-
-                    if (targetType == typeof(BaseLibrary.String))
-                        return new BaseLibrary.String(jsobj.Value.ToString());
-
-                    return null;
-                }
-                case JSValueType.Symbol:
-                {
-                    if (hightLoyalty)
-                    {
                         if (targetType == typeof(string))
                             return jsobj.Value.ToString();
-                    }
 
-                    if (targetType == typeof(Symbol))
-                        return jsobj.Value;
+                        if (targetType == typeof(BaseLibrary.String))
+                            return new BaseLibrary.String(jsobj.Value.ToString());
 
-                    return null;
-                }
-                case JSValueType.Function:
-                {
-                    if (hightLoyalty)
-                    {
-                        if (targetType == typeof(string))
-                            return jsobj.Value.ToString();
-                    }
-
-                    if (!targetType.GetTypeInfo().IsAbstract && targetType.GetTypeInfo().IsSubclassOf(typeof(Delegate)))
-                        return (jsobj.Value as Function).MakeDelegate(targetType);
-
-                    goto default;
-                }
-                default:
-                {
-                    value = jsobj.Value;
-
-                    if (value == null)
                         return null;
+                    }
+                case JSValueType.Symbol:
+                    {
+                        if (hightLoyalty)
+                        {
+                            if (targetType == typeof(string))
+                                return jsobj.Value.ToString();
+                        }
 
-                    break;
-                }
+                        if (targetType == typeof(Symbol))
+                            return jsobj.Value;
+
+                        return null;
+                    }
+                case JSValueType.Function:
+                    {
+                        if (hightLoyalty)
+                        {
+                            if (targetType == typeof(string))
+                                return jsobj.Value.ToString();
+                        }
+
+                        if (!targetType.GetTypeInfo().IsAbstract && targetType.GetTypeInfo().IsSubclassOf(typeof(Delegate)))
+                            return (jsobj.Value as Function).MakeDelegate(targetType);
+
+                        goto default;
+                    }
+                default:
+                    {
+                        value = jsobj.Value;
+
+                        if (value == null)
+                            return null;
+
+                        break;
+                    }
             }
 
             if (targetType.IsAssignableFrom(value.GetType()))
@@ -1364,175 +1431,175 @@ namespace NiL.JS.Core
                     {
                         case 'x':
                         case 'u':
-                        {
-                            if (i + (code[i] == 'u' ? 5 : 3) > code.Length)
                             {
-                                if (processRegexComp)
+                                if (i + (code[i] == 'u' ? 5 : 3) > code.Length)
                                 {
-                                    res.Append(code[i]);
-                                    break;
-                                }
-                                else
-                                    ExceptionHelper.ThrowSyntaxError("Invalid escape code (\"" + code + "\")");
-                            }
-
-                            if (fullUnicode && code[i] == 'u' && code[i + 1] == '{')
-                            {
-                                // look here in section 3.7 Surrogates for more information.
-                                // http://unicode.org/versions/Unicode3.0.0/ch03.pdf
-
-                                int closingBracket = code.IndexOf('}', i + 2);
-                                if (closingBracket == -1)
-                                    ExceptionHelper.Throw(new SyntaxError("Invalid escape sequence"));
-
-                                string c = code.Substring(i + 2, closingBracket - i - 2);
-                                uint ucs = 0;
-                                if (uint.TryParse(c, NumberStyles.HexNumber, null, out ucs))
-                                {
-                                    if (ucs <= 0xFFFF)
-                                        res.Append((char)ucs);
-                                    else if (ucs <= 0x10FFFF)
+                                    if (processRegexComp)
                                     {
-                                        ucs -= 0x10000;
-                                        char h = (char)((ucs >> 10) + 0xD800);
-                                        char l = (char)((ucs % 0x400) + 0xDC00);
-                                        res.Append(h).Append(l);
+                                        res.Append(code[i]);
+                                        break;
                                     }
                                     else
-                                        ExceptionHelper.Throw(new SyntaxError("Invalid escape sequence '\\u{" + c + "}'"));
-                                    i += c.Length + 2;
+                                        ExceptionHelper.ThrowSyntaxError("Invalid escape code (\"" + code + "\")");
                                 }
-                                else
-                                {
-                                    if (processRegexComp)
-                                        res.Append(code[i]);
-                                    else
-                                        ExceptionHelper.Throw(new SyntaxError("Invalid escape sequence '\\u{" + c + "}'"));
-                                }
-                            }
-                            else
-                            {
-                                string c = code.Substring(i + 1, code[i] == 'u' ? 4 : 2);
-                                ushort chc = 0;
-                                if (ushort.TryParse(c, NumberStyles.HexNumber, null, out chc))
-                                {
-                                    char ch = (char)chc;
-                                    res.Append(ch);
-                                    i += c.Length;
-                                }
-                                else
-                                {
-                                    if (processRegexComp)
-                                        res.Append(code[i]);
-                                    else
-                                        ExceptionHelper.Throw(new SyntaxError("Invalid escape sequence '\\" + code[i] + c + "'"));
-                                }
-                            }
 
-                            break;
-                        }
+                                if (fullUnicode && code[i] == 'u' && code[i + 1] == '{')
+                                {
+                                    // look here in section 3.7 Surrogates for more information.
+                                    // http://unicode.org/versions/Unicode3.0.0/ch03.pdf
+
+                                    int closingBracket = code.IndexOf('}', i + 2);
+                                    if (closingBracket == -1)
+                                        ExceptionHelper.Throw(new SyntaxError("Invalid escape sequence"));
+
+                                    string c = code.Substring(i + 2, closingBracket - i - 2);
+                                    uint ucs = 0;
+                                    if (uint.TryParse(c, NumberStyles.HexNumber, null, out ucs))
+                                    {
+                                        if (ucs <= 0xFFFF)
+                                            res.Append((char)ucs);
+                                        else if (ucs <= 0x10FFFF)
+                                        {
+                                            ucs -= 0x10000;
+                                            char h = (char)((ucs >> 10) + 0xD800);
+                                            char l = (char)((ucs % 0x400) + 0xDC00);
+                                            res.Append(h).Append(l);
+                                        }
+                                        else
+                                            ExceptionHelper.Throw(new SyntaxError("Invalid escape sequence '\\u{" + c + "}'"));
+                                        i += c.Length + 2;
+                                    }
+                                    else
+                                    {
+                                        if (processRegexComp)
+                                            res.Append(code[i]);
+                                        else
+                                            ExceptionHelper.Throw(new SyntaxError("Invalid escape sequence '\\u{" + c + "}'"));
+                                    }
+                                }
+                                else
+                                {
+                                    string c = code.Substring(i + 1, code[i] == 'u' ? 4 : 2);
+                                    ushort chc = 0;
+                                    if (ushort.TryParse(c, NumberStyles.HexNumber, null, out chc))
+                                    {
+                                        char ch = (char)chc;
+                                        res.Append(ch);
+                                        i += c.Length;
+                                    }
+                                    else
+                                    {
+                                        if (processRegexComp)
+                                            res.Append(code[i]);
+                                        else
+                                            ExceptionHelper.Throw(new SyntaxError("Invalid escape sequence '\\" + code[i] + c + "'"));
+                                    }
+                                }
+
+                                break;
+                            }
                         case 't':
-                        {
-                            res.Append(processRegexComp ? "\\t" : "\t");
-                            break;
-                        }
+                            {
+                                res.Append(processRegexComp ? "\\t" : "\t");
+                                break;
+                            }
                         case 'f':
-                        {
-                            res.Append(processRegexComp ? "\\f" : "\f");
-                            break;
-                        }
+                            {
+                                res.Append(processRegexComp ? "\\f" : "\f");
+                                break;
+                            }
                         case 'v':
-                        {
-                            res.Append(processRegexComp ? "\\v" : "\v");
-                            break;
-                        }
+                            {
+                                res.Append(processRegexComp ? "\\v" : "\v");
+                                break;
+                            }
                         case 'b':
-                        {
-                            res.Append(processRegexComp ? "\\b" : "\b");
-                            break;
-                        }
+                            {
+                                res.Append(processRegexComp ? "\\b" : "\b");
+                                break;
+                            }
                         case 'n':
-                        {
-                            res.Append(processRegexComp ? "\\n" : "\n");
-                            break;
-                        }
+                            {
+                                res.Append(processRegexComp ? "\\n" : "\n");
+                                break;
+                            }
                         case 'r':
-                        {
-                            res.Append(processRegexComp ? "\\r" : "\r");
-                            break;
-                        }
+                            {
+                                res.Append(processRegexComp ? "\\r" : "\r");
+                                break;
+                            }
                         case '\n':
-                        {
-                            break;
-                        }
+                            {
+                                break;
+                            }
                         case '\r':
-                        {
-                            if (code.Length > i + 1 && code[i + 1] == '\n')
-                                i++;
-                            break;
-                        }
+                            {
+                                if (code.Length > i + 1 && code[i + 1] == '\n')
+                                    i++;
+                                break;
+                            }
                         case 'c':
                         case 'C':
-                        {
-                            if (!processRegexComp)
-                                goto default;
-
-                            if (i + 1 < code.Length)
                             {
-                                char ch = code[i + 1];
-                                // convert a -> A
-                                if (ch >= 'a' && ch <= 'z')
-                                    ch = (char)(ch - ('a' - 'A'));
-                                if ((char)(ch - '@') < ' ')
-                                {
-                                    res.Append("\\c");
-                                    res.Append(ch);
-                                    ++i;
-                                    break;
-                                }
-                            }
+                                if (!processRegexComp)
+                                    goto default;
 
-                            // invalid control character
-                            goto case 'p';
-                        }
+                                if (i + 1 < code.Length)
+                                {
+                                    char ch = code[i + 1];
+                                    // convert a -> A
+                                    if (ch >= 'a' && ch <= 'z')
+                                        ch = (char)(ch - ('a' - 'A'));
+                                    if ((char)(ch - '@') < ' ')
+                                    {
+                                        res.Append("\\c");
+                                        res.Append(ch);
+                                        ++i;
+                                        break;
+                                    }
+                                }
+
+                                // invalid control character
+                                goto case 'p';
+                            }
                         // not supported in standard
                         case 'P':
                         case 'p':
                         case 'k':
                         case 'K':
-                        {
-                            if (!processRegexComp)
-                                goto default;
+                            {
+                                if (!processRegexComp)
+                                    goto default;
 
-                            // regex that does not match anything
-                            res.Append(@"\b\B");
-                            break;
-                        }
+                                // regex that does not match anything
+                                res.Append(@"\b\B");
+                                break;
+                            }
                         default:
-                        {
-                            if (!processRegexComp && code[i] >= '0' && code[i] <= '7')
                             {
-                                if (strict && (code[i] != '0' || (code.Length > i + 1 && code[i + 1] >= '0' && code[i + 1] <= '7')))
-                                    ExceptionHelper.Throw(new SyntaxError("Octal literals are not allowed in strict mode."));
+                                if (!processRegexComp && code[i] >= '0' && code[i] <= '7')
+                                {
+                                    if (strict && (code[i] != '0' || (code.Length > i + 1 && code[i + 1] >= '0' && code[i + 1] <= '7')))
+                                        ExceptionHelper.Throw(new SyntaxError("Octal literals are not allowed in strict mode."));
 
-                                var ccode = code[i] - '0';
-                                if (i + 1 < code.Length && code[i + 1] >= '0' && code[i + 1] <= '7')
-                                    ccode = ccode * 8 + (code[++i] - '0');
-                                if (i + 1 < code.Length && code[i + 1] >= '0' && code[i + 1] <= '7')
-                                    ccode = ccode * 8 + (code[++i] - '0');
-                                res.Append((char)ccode);
+                                    var ccode = code[i] - '0';
+                                    if (i + 1 < code.Length && code[i + 1] >= '0' && code[i + 1] <= '7')
+                                        ccode = ccode * 8 + (code[++i] - '0');
+                                    if (i + 1 < code.Length && code[i + 1] >= '0' && code[i + 1] <= '7')
+                                        ccode = ccode * 8 + (code[++i] - '0');
+                                    res.Append((char)ccode);
+                                }
+                                else if (processUnknown)
+                                {
+                                    res.Append(code[i]);
+                                }
+                                else
+                                {
+                                    res.Append('\\');
+                                    res.Append(code[i]);
+                                }
+                                break;
                             }
-                            else if (processUnknown)
-                            {
-                                res.Append(code[i]);
-                            }
-                            else
-                            {
-                                res.Append('\\');
-                                res.Append(code[i]);
-                            }
-                            break;
-                        }
                     }
                 }
                 else if (res != null)
@@ -1579,74 +1646,74 @@ namespace NiL.JS.Core
                 {
                     case 'x':
                     case 'u':
-                    {
-                        if (i + (code[i] == 'u' ? 5 : 3) > code.Length)
                         {
-                            if (processRegexComp)
-                                return code[i].ToString();
-                            else
-                                ExceptionHelper.Throw(new SyntaxError("Invalid escape code (\"" + code + "\")"));
-                        }
-
-                        if (code[i] == 'u' && code[i + 1] == '{')
-                        {
-                            if (fullUnicode)
+                            if (i + (code[i] == 'u' ? 5 : 3) > code.Length)
                             {
-                                // look here in section 3.7 Surrogates for more information.
-                                // http://unicode.org/versions/Unicode3.0.0/ch03.pdf
+                                if (processRegexComp)
+                                    return code[i].ToString();
+                                else
+                                    ExceptionHelper.Throw(new SyntaxError("Invalid escape code (\"" + code + "\")"));
+                            }
 
-                                int closingBracket = code.IndexOf('}', i + 2);
-                                if (closingBracket == -1)
-                                    ExceptionHelper.Throw(new SyntaxError("Invalid escape sequence"));
-
-                                string c = code.Substring(i + 2, closingBracket - i - 2);
-                                uint ucs = 0;
-                                if (uint.TryParse(c, NumberStyles.HexNumber, null, out ucs))
+                            if (code[i] == 'u' && code[i + 1] == '{')
+                            {
+                                if (fullUnicode)
                                 {
-                                    processedChars += c.Length + 2;
-                                    if (ucs <= 0xFFFF)
-                                        return ((char)ucs).ToString();
-                                    else if (ucs <= 0x10FFFF)
+                                    // look here in section 3.7 Surrogates for more information.
+                                    // http://unicode.org/versions/Unicode3.0.0/ch03.pdf
+
+                                    int closingBracket = code.IndexOf('}', i + 2);
+                                    if (closingBracket == -1)
+                                        ExceptionHelper.Throw(new SyntaxError("Invalid escape sequence"));
+
+                                    string c = code.Substring(i + 2, closingBracket - i - 2);
+                                    uint ucs = 0;
+                                    if (uint.TryParse(c, NumberStyles.HexNumber, null, out ucs))
                                     {
-                                        ucs -= 0x10000;
-                                        char h = (char)((ucs >> 10) + 0xD800);
-                                        char l = (char)((ucs % 0x400) + 0xDC00);
-                                        return h.ToString() + l.ToString();
+                                        processedChars += c.Length + 2;
+                                        if (ucs <= 0xFFFF)
+                                            return ((char)ucs).ToString();
+                                        else if (ucs <= 0x10FFFF)
+                                        {
+                                            ucs -= 0x10000;
+                                            char h = (char)((ucs >> 10) + 0xD800);
+                                            char l = (char)((ucs % 0x400) + 0xDC00);
+                                            return h.ToString() + l.ToString();
+                                        }
+                                        else
+                                            ExceptionHelper.Throw(new SyntaxError("Invalid escape sequence '\\u{" + c + "}'"));
                                     }
                                     else
-                                        ExceptionHelper.Throw(new SyntaxError("Invalid escape sequence '\\u{" + c + "}'"));
+                                    {
+                                        if (processRegexComp)
+                                            return code[i].ToString();
+                                        else
+                                            ExceptionHelper.Throw(new SyntaxError("Invalid escape sequence '\\u{" + c + "}'"));
+                                    }
+                                }
+                                else
+                                    return code[i].ToString();
+                            }
+                            else
+                            {
+                                string c = code.Substring(i + 1, code[i] == 'u' ? 4 : 2);
+                                ushort chc = 0;
+                                if (ushort.TryParse(c, System.Globalization.NumberStyles.HexNumber, null, out chc))
+                                {
+                                    processedChars += c.Length;
+                                    char ch = (char)chc;
+                                    return ch.ToString();
                                 }
                                 else
                                 {
                                     if (processRegexComp)
                                         return code[i].ToString();
                                     else
-                                        ExceptionHelper.Throw(new SyntaxError("Invalid escape sequence '\\u{" + c + "}'"));
+                                        ExceptionHelper.Throw(new SyntaxError("Invalid escape sequence '\\" + code[i] + c + "'"));
                                 }
                             }
-                            else
-                                return code[i].ToString();
+                            return code[i].ToString(); // this will never be reached
                         }
-                        else
-                        {
-                            string c = code.Substring(i + 1, code[i] == 'u' ? 4 : 2);
-                            ushort chc = 0;
-                            if (ushort.TryParse(c, System.Globalization.NumberStyles.HexNumber, null, out chc))
-                            {
-                                processedChars += c.Length;
-                                char ch = (char)chc;
-                                return ch.ToString();
-                            }
-                            else
-                            {
-                                if (processRegexComp)
-                                    return code[i].ToString();
-                                else
-                                    ExceptionHelper.Throw(new SyntaxError("Invalid escape sequence '\\" + code[i] + c + "'"));
-                            }
-                        }
-                        return code[i].ToString(); // this will never be reached
-                    }
                     case 't':
                         return (processRegexComp ? "\\t" : "\t");
                     case 'f':
@@ -1660,76 +1727,76 @@ namespace NiL.JS.Core
                     case 'r':
                         return (processRegexComp ? "\\r" : "\r");
                     case '\n':
-                    {
-                        return "";
-                    }
+                        {
+                            return "";
+                        }
                     case '\r':
-                    {
-                        if (code.Length > i + 1 && code[i] == '\n')
-                            processedChars = 3;
-                        return "";
-                    }
+                        {
+                            if (code.Length > i + 1 && code[i] == '\n')
+                                processedChars = 3;
+                            return "";
+                        }
                     case 'c':
                     case 'C':
-                    {
-                        if (!processRegexComp)
-                            goto default;
-
-                        if (i + 1 < code.Length)
                         {
-                            char ch = code[i + 1];
-                            // convert a -> A
-                            if (ch >= 'a' && ch <= 'z')
-                                ch = (char)(ch - ('a' - 'A'));
-                            if ((char)(ch - '@') < ' ')
-                            {
-                                processedChars++;
-                                return "\\c" + ch.ToString();
-                            }
-                        }
+                            if (!processRegexComp)
+                                goto default;
 
-                        // invalid control character
-                        goto case 'p';
-                    }
+                            if (i + 1 < code.Length)
+                            {
+                                char ch = code[i + 1];
+                                // convert a -> A
+                                if (ch >= 'a' && ch <= 'z')
+                                    ch = (char)(ch - ('a' - 'A'));
+                                if ((char)(ch - '@') < ' ')
+                                {
+                                    processedChars++;
+                                    return "\\c" + ch.ToString();
+                                }
+                            }
+
+                            // invalid control character
+                            goto case 'p';
+                        }
                     // not supported in standard
                     case 'P':
                     case 'p':
                     case 'k':
                     case 'K':
-                    {
-                        if (!processRegexComp)
-                            goto default;
+                        {
+                            if (!processRegexComp)
+                                goto default;
 
-                        // regex that does not match anything
-                        return @"\b\B";
-                    }
+                            // regex that does not match anything
+                            return @"\b\B";
+                        }
                     default:
-                    {
-                        if (code[i] >= '0' && code[i] <= '7' && !processRegexComp)
                         {
-                            if (strict)
-                                ExceptionHelper.Throw(new SyntaxError("Octal literals are not allowed in strict mode."));
+                            if (code[i] >= '0' && code[i] <= '7' && !processRegexComp)
+                            {
+                                if (strict)
+                                    ExceptionHelper.Throw(new SyntaxError("Octal literals are not allowed in strict mode."));
 
-                            var ccode = code[i] - '0';
-                            if (i + 1 < code.Length && code[i + 1] >= '0' && code[i + 1] <= '7')
-                            {
-                                ccode = ccode * 8 + (code[++i] - '0');
-                                processedChars++;
+                                var ccode = code[i] - '0';
+                                if (i + 1 < code.Length && code[i + 1] >= '0' && code[i + 1] <= '7')
+                                {
+                                    ccode = ccode * 8 + (code[++i] - '0');
+                                    processedChars++;
+                                }
+                                if (i + 1 < code.Length && code[i + 1] >= '0' && code[i + 1] <= '7')
+                                {
+                                    ccode = ccode * 8 + (code[++i] - '0');
+                                    processedChars++;
+                                }
+                                return ((char)ccode).ToString();
                             }
-                            if (i + 1 < code.Length && code[i + 1] >= '0' && code[i + 1] <= '7')
+                            else
                             {
-                                ccode = ccode * 8 + (code[++i] - '0');
-                                processedChars++;
+                                if (!processUnknown)
+                                    return "\\" + code[i].ToString();
+                                return code[i].ToString();
                             }
-                            return ((char)ccode).ToString();
                         }
-                        else
-                        {
-                            if (!processUnknown)
-                                return "\\" + code[i].ToString();
-                            return code[i].ToString();
-                        }
-                    }
                 }
             }
 
@@ -2158,51 +2225,51 @@ namespace NiL.JS.Core
                 case JSValueType.Symbol:
                     return "Symbol";
                 case JSValueType.Object:
-                {
-                    var o = v as ObjectWrapper;
-                    if (o == null)
-                        o = v._oValue as ObjectWrapper;
-                    if (o != null)
-                        return o.Value.GetType().Name;
-
-                    if (v._oValue == null)
-                        return "null";
-
-                    if (v._oValue is GlobalObject)
-                        return "global";
-
-                    if (v._oValue is Proxy)
                     {
-                        var hostedType = (v._oValue as Proxy)._hostedType;
-                        if (hostedType == typeof(JSObject))
-                            return "Object";
-                        return hostedType.Name;
-                    }
+                        var o = v as ObjectWrapper;
+                        if (o == null)
+                            o = v._oValue as ObjectWrapper;
+                        if (o != null)
+                            return o.Value.GetType().Name;
 
-                    if (v.Value.GetType() == typeof(JSObject))
-                        return "Object";
-                    return v.Value.GetType().Name;
-                }
+                        if (v._oValue == null)
+                            return "null";
+
+                        if (v._oValue is GlobalObject)
+                            return "global";
+
+                        if (v._oValue is Proxy)
+                        {
+                            var hostedType = (v._oValue as Proxy)._hostedType;
+                            if (hostedType == typeof(JSObject))
+                                return "Object";
+                            return hostedType.Name;
+                        }
+
+                        if (v.Value.GetType() == typeof(JSObject))
+                            return "Object";
+                        return v.Value.GetType().Name;
+                    }
                 case JSValueType.Function:
                     return "Function";
                 case JSValueType.Date:
                     return "Date";
                 case JSValueType.Property:
-                {
-                    var prop = v._oValue as PropertyPair;
-                    if (prop != null)
                     {
-                        var tempStr = "";
-                        if (prop.getter != null)
-                            tempStr += "Getter";
-                        if (prop.setter != null)
-                            tempStr += ((tempStr.Length > 0) ? "/" : "") + "Setter";
-                        if (tempStr.Length == 0)
-                            tempStr = "Invalid";
-                        return tempStr + " Property";
+                        var prop = v._oValue as PropertyPair;
+                        if (prop != null)
+                        {
+                            var tempStr = "";
+                            if (prop.getter != null)
+                                tempStr += "Getter";
+                            if (prop.setter != null)
+                                tempStr += ((tempStr.Length > 0) ? "/" : "") + "Setter";
+                            if (tempStr.Length == 0)
+                                tempStr = "Invalid";
+                            return tempStr + " Property";
+                        }
+                        return "Property";
                     }
-                    return "Property";
-                }
                 default:
                     throw new NotImplementedException();
             }
@@ -2226,141 +2293,141 @@ namespace NiL.JS.Core
             switch (v.ValueType)
             {
                 case JSValueType.String:
-                {
-                    return "\"" + v.ToString() + "\"";
-                }
-                case JSValueType.Date:
-                {
-                    string dstr = v.ToString();
-                    if (dstr == "Invalid date")
-                        return dstr;
-                    return "Date " + dstr;
-                }
-                case JSValueType.Function:
-                {
-                    BaseLibrary.Function f = v.Value as BaseLibrary.Function;
-                    if (f == null)
-                        return v.ToString();
-                    if (recursionDepth >= maxRecursionDepth)
-                        return f.name + "()";
-                    if (recursionDepth == maxRecursionDepth - 1)
-                        return f.ToString(true);
-                    return f.ToString();
-                }
-                case JSValueType.Object:
-                {
-                    if (v._oValue == null)
-                        return "null";
-
-                    if (v.Value is RegExp)
-                        return v.ToString();
-
-                    if (v.Value is BaseLibrary.Array
-                        || v.Value == Context.CurrentGlobalContext.GetPrototype(typeof(BaseLibrary.Array))
-                        || v == Context.CurrentGlobalContext.GetPrototype(typeof(BaseLibrary.Array)))
                     {
-                        BaseLibrary.Array a = v.Value as BaseLibrary.Array;
-                        StringBuilder s;
+                        return "\"" + v.ToString() + "\"";
+                    }
+                case JSValueType.Date:
+                    {
+                        string dstr = v.ToString();
+                        if (dstr == "Invalid date")
+                            return dstr;
+                        return "Date " + dstr;
+                    }
+                case JSValueType.Function:
+                    {
+                        BaseLibrary.Function f = v.Value as BaseLibrary.Function;
+                        if (f == null)
+                            return v.ToString();
+                        if (recursionDepth >= maxRecursionDepth)
+                            return f.name + "()";
+                        if (recursionDepth == maxRecursionDepth - 1)
+                            return f.ToString(true);
+                        return f.ToString();
+                    }
+                case JSValueType.Object:
+                    {
+                        if (v._oValue == null)
+                            return "null";
 
-                        if (a == null) // v == Array.prototype
+                        if (v.Value is RegExp)
+                            return v.ToString();
+
+                        if (v.Value is BaseLibrary.Array
+                            || v.Value == Context.CurrentGlobalContext.GetPrototype(typeof(BaseLibrary.Array))
+                            || v == Context.CurrentGlobalContext.GetPrototype(typeof(BaseLibrary.Array)))
                         {
-                            s = new StringBuilder("Array [ ");
-                            int j = 0;
-                            for (var e = v.GetEnumerator(true, EnumerationMode.RequireValues); e.MoveNext();)
+                            BaseLibrary.Array a = v.Value as BaseLibrary.Array;
+                            StringBuilder s;
+
+                            if (a == null) // v == Array.prototype
                             {
-                                if (j++ > 0)
-                                    s.Append(", ");
-                                s.Append(e.Current.Key).Append(": ");
-                                s.Append(Tools.JSValueToObjectString(e.Current.Value, maxRecursionDepth, recursionDepth + 1));
+                                s = new StringBuilder("Array [ ");
+                                int j = 0;
+                                for (var e = v.GetEnumerator(true, EnumerationMode.RequireValues); e.MoveNext();)
+                                {
+                                    if (j++ > 0)
+                                        s.Append(", ");
+                                    s.Append(e.Current.Key).Append(": ");
+                                    s.Append(Tools.JSValueToObjectString(e.Current.Value, maxRecursionDepth, recursionDepth + 1));
+                                }
+                                s.Append(" ]");
+                                return s.ToString();
+                            }
+
+                            long len = (long)a.length;
+
+                            if (recursionDepth >= maxRecursionDepth)
+                                return $"Array[{len}]";
+
+                            s = new StringBuilder($"Array ({len}) [ ");
+                            int i = 0;
+                            int undefs = 0;
+                            for (i = 0; i < len; i++)
+                            {
+                                var val = a[i];
+                                if (undefs > 1)
+                                {
+                                    if (val != null && val._valueType <= JSValueType.Undefined)
+                                        undefs++;
+                                    else
+                                    {
+                                        s.Append(" x ").Append(undefs);
+                                        s.Append(", ");
+                                        s.Append(Tools.JSValueToObjectString(val, maxRecursionDepth, recursionDepth + 1));
+                                        undefs = 0;
+                                    }
+                                }
+                                else
+                                {
+                                    if (val != null && val._valueType <= JSValueType.Undefined)
+                                    {
+                                        if (++undefs > 1)
+                                            continue;
+                                    }
+                                    else
+                                        undefs = 0;
+                                    if (i > 0)
+                                        s.Append(", ");
+                                    s.Append(Tools.JSValueToObjectString(val, maxRecursionDepth, recursionDepth + 1));
+                                }
+                            }
+                            if (undefs > 0)
+                                s.Append(" x ").Append(undefs);
+
+                            if (a._fields != null)
+                            {
+                                for (var e = a._fields.GetEnumerator(); e.MoveNext();)
+                                {
+                                    if (i++ > 0)
+                                        s.Append(", ");
+                                    s.Append(e.Current.Key).Append(": ");
+                                    s.Append(Tools.JSValueToObjectString(e.Current.Value, maxRecursionDepth, recursionDepth + 1));
+                                }
                             }
                             s.Append(" ]");
+
                             return s.ToString();
                         }
-
-                        long len = (long)a.length;
-
-                        if (recursionDepth >= maxRecursionDepth)
-                            return $"Array[{len}]";
-
-                        s = new StringBuilder($"Array ({len}) [ ");
-                        int i = 0;
-                        int undefs = 0;
-                        for (i = 0; i < len; i++)
+                        else
                         {
-                            var val = a[i];
-                            if (undefs > 1)
-                            {
-                                if (val != null && val._valueType <= JSValueType.Undefined)
-                                    undefs++;
-                                else
-                                {
-                                    s.Append(" x ").Append(undefs);
-                                    s.Append(", ");
-                                    s.Append(Tools.JSValueToObjectString(val, maxRecursionDepth, recursionDepth + 1));
-                                    undefs = 0;
-                                }
-                            }
-                            else
-                            {
-                                if (val != null && val._valueType <= JSValueType.Undefined)
-                                {
-                                    if (++undefs > 1)
-                                        continue;
-                                }
-                                else
-                                    undefs = 0;
-                                if (i > 0)
-                                    s.Append(", ");
-                                s.Append(Tools.JSValueToObjectString(val, maxRecursionDepth, recursionDepth + 1));
-                            }
-                        }
-                        if (undefs > 0)
-                            s.Append(" x ").Append(undefs);
+                            string typeName = Tools.GetTypeName(v);
+                            if (recursionDepth >= maxRecursionDepth)
+                                return typeName;
 
-                        if (a._fields != null)
-                        {
-                            for (var e = a._fields.GetEnumerator(); e.MoveNext();)
+                            StringBuilder s = new StringBuilder(typeName);
+                            s.Append(" { ");
+
+                            JSObject o = v as JSObject;
+                            if (o == null)
+                                o = v._oValue as JSObject;
+                            if (o == null)
+                                return v.ToString();
+
+
+                            int i = 0;
+                            for (var e = o.GetEnumerator(true, EnumerationMode.RequireValues); e.MoveNext();)
                             {
                                 if (i++ > 0)
                                     s.Append(", ");
                                 s.Append(e.Current.Key).Append(": ");
                                 s.Append(Tools.JSValueToObjectString(e.Current.Value, maxRecursionDepth, recursionDepth + 1));
                             }
+
+                            s.Append(" }");
+
+                            return s.ToString();
                         }
-                        s.Append(" ]");
-
-                        return s.ToString();
                     }
-                    else
-                    {
-                        string typeName = Tools.GetTypeName(v);
-                        if (recursionDepth >= maxRecursionDepth)
-                            return typeName;
-
-                        StringBuilder s = new StringBuilder(typeName);
-                        s.Append(" { ");
-
-                        JSObject o = v as JSObject;
-                        if (o == null)
-                            o = v._oValue as JSObject;
-                        if (o == null)
-                            return v.ToString();
-
-
-                        int i = 0;
-                        for (var e = o.GetEnumerator(true, EnumerationMode.RequireValues); e.MoveNext();)
-                        {
-                            if (i++ > 0)
-                                s.Append(", ");
-                            s.Append(e.Current.Key).Append(": ");
-                            s.Append(Tools.JSValueToObjectString(e.Current.Value, maxRecursionDepth, recursionDepth + 1));
-                        }
-
-                        s.Append(" }");
-
-                        return s.ToString();
-                    }
-                }
             }
 
             return v.ToString();

--- a/NiL.JS/Expressions/Call.cs
+++ b/NiL.JS/Expressions/Call.cs
@@ -73,6 +73,7 @@ namespace NiL.JS.Expressions
 
         public override JSValue Evaluate(Context context)
         {
+            context._currentPosition = this.Position;
             var temp = _left.Evaluate(context);
             JSValue targetObject = context._objectSource;
             ICallable callable = null;

--- a/NiL.JS/Expressions/NewTarget.cs
+++ b/NiL.JS/Expressions/NewTarget.cs
@@ -42,7 +42,7 @@ namespace NiL.JS.Expressions
         {
             if (context._thisBind != null && (context._thisBind._attributes & JSValueAttributesInternal.ConstructingObject) != 0)
             {
-                var stack = Context.GetCurrectContextStack();
+                var stack = Context.GetCurrentContextStack();
 
                 var i = 2;
                 while (stack.Count >= i && stack[stack.Count - i]._thisBind == context._thisBind)

--- a/NiL.JS/Script.cs
+++ b/NiL.JS/Script.cs
@@ -62,6 +62,8 @@ namespace NiL.JS
             if (Code == "")
                 return JSValue.Undefined;
 
+            context._code = Code;
+
             try
             {
                 context.Activate();

--- a/NiL.JS/Statements/ImportStatement.cs
+++ b/NiL.JS/Statements/ImportStatement.cs
@@ -103,6 +103,7 @@ namespace NiL.JS.Statements
 
             result._moduleName = Tools.Unescape(state.Code.Substring(start + 1, index - start - 2), false);
 
+            result.Position = start;
             return result;
         }
 
@@ -168,6 +169,7 @@ namespace NiL.JS.Statements
 
         public override JSValue Evaluate(Context context)
         {
+            context._currentPosition = this.Position;
             if (context._module == null)
                 ExceptionHelper.Throw(new BaseLibrary.Error("Module undefined"));
             if (string.IsNullOrEmpty(context._module.FilePath))


### PR DESCRIPTION
I tried another idea, can you try to perfect it?

example:
```
using ExamplesFramework;
using NiL.JS;
using NiL.JS.Core;
using System;

namespace Examples.Run_script
{
    [Level(0)]
    public sealed class Get_stack : Example
    {
        private static readonly string _code = @"
try{
var text = `
test callstack
MissingThing${missingThing}
`;
}
catch(e){
console.log(e.toString());
}

try{
ClrTest();
}
catch(e){
console.log(e.toString());
}


try{
import Test from 'test';

new Test().test();
}
catch(e){
console.log(e.toString());
}
";
        public override void Run()
        {
            var mainModule = new Module("main.js", _code);
            mainModule.ModuleResolversChain.Add(new MyTestModuleResolver());
            mainModule.Context.DefineVariable("ClrTest").Assign(JSValue.Marshal(new Action(() => { throw new Exception("clr error"); })));
            mainModule.Run();
        }

        public sealed class MyTestModuleResolver : CachedModuleResolverBase
        {
            public override bool TryGetModule(ModuleRequest moduleRequest, out Module result)
            {
                if (moduleRequest.AbsolutePath == "/test.js")
                {
                    result = new Module(moduleRequest.AbsolutePath, @"
class Test{
    test() {
        this.test2();
    }

    test1() {
        this.test3();
    }
    test2() {
        var x = new MissingThing(1, 2, 3);
    }
}
export default Test;
");
                    return true;
                }

                result = null;
                return false;
            }
        }
    }
}
```

output:
```
ReferenceError: Variable "missingThing" is not defined
    at MissingThing${missingThing}
    at <anonymous method>(main.js:5:15)

TypeError: clr error
    at ClrTest();
    at <anonymous method>(main.js:13:1)

ReferenceError: Variable "MissingThing" is not defined
    at var x = new MissingThing(1, 2, 3);
    at test2(/test.js:11:21)
    at test(/test.js:4:9)
    at <anonymous method>(main.js:23:5)
```