### PR TITLE
Fix double conversion to string

### DIFF
--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -856,10 +856,10 @@ namespace NiL.JS.Core
                         ulong absIntPart = (abs < 1.0) ? 0L : (ulong)(abs);
                         res = (absIntPart == 0 ? "0" : absIntPart.ToString(CultureInfo.InvariantCulture));
 
-                        abs %= 1.0;
-                        if (abs != 0 && res.Length <= 15)
+                        var decimalPart = Convert.ToDecimal(abs) % 1.0m;
+                        if (decimalPart != 0 && res.Length <= 15)
                         {
-                            string fracPart = abs.ToString(divFormats[15 - res.Length], CultureInfo.InvariantCulture);
+                            string fracPart = decimalPart.ToString(divFormats[15 - res.Length], CultureInfo.InvariantCulture);
                             if (fracPart == "1")
                                 res = (absIntPart + 1).ToString(CultureInfo.InvariantCulture);
                             else

--- a/Tests/Core/ToolsTests.cs
+++ b/Tests/Core/ToolsTests.cs
@@ -31,17 +31,38 @@ namespace Tests.Core
                 new KeyValuePair<double, string>(1664158979.1109629, "1664158979.11096290000000000000"),
                 new KeyValuePair<double, string>(0.00021140449751288852, "0.00021140449751288852"),
                 new KeyValuePair<double, string>(34.970703125, "34.970703125"),
-                new KeyValuePair<double, string>(1.7158203125, "1.7158203125"),
-                new KeyValuePair<double, string>(0.6, "0.6")
+                new KeyValuePair<double, string>(1.7158203125, "1.7158203125")
             };
 
             foreach (var number in numbers)
             {
-                var parsedNumber = 0.0;
-                var result = Tools.ParseNumber(number.Value, out parsedNumber, 0);
+                var result = Tools.ParseNumber(number.Value, out double parsedNumber, 0);
 
                 Assert.IsTrue(result);
                 Assert.AreEqual(number.Key, parsedNumber);
+            }
+        }
+
+        [TestMethod]
+        public void DoubleToString()
+        {
+            var numbers = new KeyValuePair<double, string>[]
+            {
+                new KeyValuePair<double, string>(69.85, "69.85"),
+                new KeyValuePair<double, string>(10.2, "10.2"),
+                new KeyValuePair<double, string>(12.34, "12.34"),
+                new KeyValuePair<double, string>(1.3, "1.3"),
+                new KeyValuePair<double, string>(20.20, "20.2"),
+                new KeyValuePair<double, string>(0.00021140449751288852, "0.000211404497513"),
+                new KeyValuePair<double, string>(34.970703125, "34.970703125"),
+                new KeyValuePair<double, string>(1.7158203125, "1.7158203125")
+            };
+
+            foreach (var (number, expected) in numbers)
+            {
+                var parsedNumber = Tools.DoubleToString(number);
+
+                Assert.AreEqual(expected, parsedNumber);
             }
         }
 

--- a/Tests/Core/ToolsTests.cs
+++ b/Tests/Core/ToolsTests.cs
@@ -31,7 +31,8 @@ namespace Tests.Core
                 new KeyValuePair<double, string>(1664158979.1109629, "1664158979.11096290000000000000"),
                 new KeyValuePair<double, string>(0.00021140449751288852, "0.00021140449751288852"),
                 new KeyValuePair<double, string>(34.970703125, "34.970703125"),
-                new KeyValuePair<double, string>(1.7158203125, "1.7158203125")
+                new KeyValuePair<double, string>(1.7158203125, "1.7158203125"),
+                new KeyValuePair<double, string>(0.6, "0.6")
             };
 
             foreach (var number in numbers)


### PR DESCRIPTION
Fix the conversion from double to string where in some cases the process that extracts the decimal places from the original number was affected by a loss of precision e.g the original number 69.85 was converted to 69.84999999999999.