### PR TITLE
fix: unpack jsvalue on `Set` methods

### DIFF
--- a/NiL.JS/BaseLibrary/Set.cs
+++ b/NiL.JS/BaseLibrary/Set.cs
@@ -32,12 +32,16 @@ namespace NiL.JS.BaseLibrary
 
             foreach (var value in iterable.AsEnumerable())
             {                
-                _storage.Add(value.Value as JSValue ?? value);
+                _storage.Add(value.Value);
             }
         }
 
         public Set add(object item)
         {
+            if (item == null)
+                item = JSValue.@null;
+            else
+                item = (item as JSValue)?.Value ?? item;
             _storage.Add(item);
 
             return this;
@@ -50,11 +54,19 @@ namespace NiL.JS.BaseLibrary
 
         public bool delete(object key)
         {
+            if (key == null)
+                key = JSValue.@null;
+            else
+                key = (key as JSValue)?.Value ?? key;
             return _storage.Remove(key);
         }
 
         public bool has(object key)
         {
+            if (key == null)
+                key = JSValue.@null;
+            else
+                key = (key as JSValue)?.Value ?? key;
             return _storage.Contains(key);
         }
 

--- a/Tests/BaseLibrary/SetTests.cs
+++ b/Tests/BaseLibrary/SetTests.cs
@@ -19,7 +19,7 @@ namespace Tests.BaseLibrary
         }
 
         [TestMethod]
-        public void RemovesElements()
+        public void ContainsElement()
         {
             var script = @"
 const s=new Set([1,2,3,4]);
@@ -30,5 +30,33 @@ s.has(2);";
             Assert.AreEqual(JSValueType.Boolean, result.ValueType);
             Assert.AreEqual(true, result.Value);
         }
+
+
+        [TestMethod]
+        public void DeletesElement()
+        {
+            var script = @"
+const s=new Set([1,2,3,4]);
+s.delete(2);";
+            var context = new Context();
+            var result = context.Eval(script);
+
+            Assert.AreEqual(JSValueType.Boolean, result.ValueType);
+            Assert.AreEqual(true, result.Value);
+        }
+
+        [TestMethod]
+        public void DontAddElement()
+        {
+            var script = @"
+const s = new Set([1,2,3,4]);
+s.add(2).size;";
+            var context = new Context();
+            var result = context.Eval(script);
+
+            Assert.AreEqual(JSValueType.Integer, result.ValueType);
+            Assert.AreEqual(4, result.Value);
+        }
+
     }
 }

--- a/Tests/BaseLibrary/SetTests.cs
+++ b/Tests/BaseLibrary/SetTests.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NiL.JS.Core;
+
+namespace Tests.BaseLibrary
+{
+    [TestClass]
+    public class SetTests
+    {
+        [TestInitializeAttribute]
+        public void TestInitialize()
+        {
+            new GlobalContext().ActivateInCurrentThread();
+        }
+
+        [TestCleanup]
+        public void MyTestMethod()
+        {
+            Context.CurrentContext.GlobalContext.Deactivate();
+        }
+
+        [TestMethod]
+        public void RemovesElements()
+        {
+            var script = @"
+const s=new Set([1,2,3,4]);
+s.has(2);";
+            var context = new Context();
+            var result = context.Eval(script);
+
+            Assert.AreEqual(JSValueType.Boolean, result.ValueType);
+            Assert.AreEqual(true, result.Value);
+        }
+    }
+}


### PR DESCRIPTION
The `JSValue` needs to be "unpacked" before passing to `HashSet`

- closes #265