### PR TITLE
Let new Date() and Date.now() be in the current timezone

### DIFF
--- a/NiL.JS/BaseLibrary/Date.cs
+++ b/NiL.JS/BaseLibrary/Date.cs
@@ -1119,7 +1119,7 @@ namespace NiL.JS.BaseLibrary
                 else
                 {
                     if (year < 100)
-                        year += (Context.CurrentGlobalContext.Year / 100) * 100;
+                        year += (Context.CurrentGlobalContext.Now.Year / 100) * 100;
                 }
 
                 time = dateToMilliseconds(year, month - 1, day,

--- a/NiL.JS/BaseLibrary/Date.cs
+++ b/NiL.JS/BaseLibrary/Date.cs
@@ -51,8 +51,9 @@ namespace NiL.JS.BaseLibrary
         [DoNotEnumerate]
         public Date()
         {
-            _time = DateTime.Now.Ticks / 10000;
-            _timeZoneOffset = Context.CurrentGlobalContext.CurrentTimeZone.GetUtcOffset(DateTime.Now).Ticks / 10000;
+            var now = Context.CurrentGlobalContext.Now;
+            _time = now.Ticks / 10000;
+            _timeZoneOffset = Context.CurrentGlobalContext.CurrentTimeZone.GetUtcOffset(now).Ticks / 10000;
             _time -= _timeZoneOffset;
         }
 
@@ -63,6 +64,13 @@ namespace NiL.JS.BaseLibrary
             _timeZoneOffset = Context.CurrentGlobalContext.CurrentTimeZone.GetUtcOffset(dateTime).Ticks / 10000;
             if (dateTime.Kind != DateTimeKind.Utc)
                 _time -= _timeZoneOffset;
+        }
+
+        [DoNotEnumerate]
+        public Date(DateTimeOffset dateTimeOffset)
+        {
+            _time = dateTimeOffset.UtcTicks / 10000;
+            _timeZoneOffset = dateTimeOffset.Offset.Ticks / 10000;
         }
 
         [DoNotEnumerate]
@@ -235,8 +243,9 @@ namespace NiL.JS.BaseLibrary
         [DoNotEnumerate]
         public static JSValue now()
         {
-            var time = DateTime.Now.Ticks / 10000;
-            var timeZoneOffset = Context.CurrentGlobalContext.CurrentTimeZone.GetUtcOffset(DateTime.Now).Ticks / 10000;
+            var now = Context.CurrentGlobalContext.Now;
+            var time = now.Ticks / 10000;
+            var timeZoneOffset = Context.CurrentGlobalContext.CurrentTimeZone.GetUtcOffset(now).Ticks / 10000;
             return time - timeZoneOffset - _unixTimeBase;
         }
 
@@ -1105,12 +1114,12 @@ namespace NiL.JS.BaseLibrary
 
                 if (!wasYear)
                 {
-                    year = DateTime.Now.Year;
+                    year = Context.CurrentGlobalContext.Now.Year;
                 }
                 else
                 {
                     if (year < 100)
-                        year += (DateTime.Now.Year / 100) * 100;
+                        year += (Context.CurrentGlobalContext.Year / 100) * 100;
                 }
 
                 time = dateToMilliseconds(year, month - 1, day,
@@ -1354,7 +1363,7 @@ namespace NiL.JS.BaseLibrary
                 day = 1;
 
             if (year < 100)
-                year += (DateTime.Now.Year / 100) * 100;
+                year += (Context.CurrentGlobalContext.Now.Year / 100) * 100;
 
             time = dateToMilliseconds(year, month - 1, day, hour, minutes, seconds, milliseconds);
 

--- a/NiL.JS/Core/GlobalContext.cs
+++ b/NiL.JS/Core/GlobalContext.cs
@@ -33,6 +33,8 @@ namespace NiL.JS.Core
         public JsonSerializersRegistry JsonSerializersRegistry { get; set; }
         public TimeZoneInfo CurrentTimeZone { get; set; }
 
+        internal DateTime Now => TimeZoneInfo.ConvertTime(DateTime.UtcNow, TimeZoneInfo.Utc, CurrentTimeZone);
+
         public GlobalContext()
             : this("")
         {


### PR DESCRIPTION
Currently, `DateTime.Now` is used when constructing e.g. `new Date()`, but that creates times based on the current machine. Instead times should be created in the current timezone configured on the global context.