### PR TITLE
Added parsing of Guid from JS strings (with tests)

### DIFF
--- a/NiL.JS/Core/Tools.cs
+++ b/NiL.JS/Core/Tools.cs
@@ -655,6 +655,11 @@ namespace NiL.JS.Core
                                     return null;
                                 }
                             }
+
+                            if (targetType == typeof(Guid))
+                            {
+                                return Guid.Parse(jsobj.Value.ToString());
+                            }
                         }
 
                         if (targetType == typeof(string))

--- a/Tests/Core/GuidTests.cs
+++ b/Tests/Core/GuidTests.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NiL.JS.Core;
+using NiL.JS.Extensions;
+using System;
+
+namespace Tests.Core
+{
+	[TestClass]
+	public class GuidTests
+	{
+		[TestMethod]
+		public void AsParsesGuids()
+		{
+			string script = @"var output = '5d063342-47c6-4948-b29b-0487e0884265'";
+			Context jsContext = new Context();
+			jsContext.Eval(script, true);
+			Guid output = jsContext.GetVariable("output").As<Guid>();
+
+			Assert.AreEqual(Guid.Parse("5d063342-47c6-4948-b29b-0487e0884265"), output);
+		}
+
+		[TestMethod]
+		public void AsParsesNullableGuids()
+		{
+			string script = @"var output = '5d063342-47c6-4948-b29b-0487e0884265'";
+			Context jsContext = new Context();
+			jsContext.Eval(script, true);
+			Guid? output = jsContext.GetVariable("output").As<Guid?>();
+
+			Assert.AreEqual(Guid.Parse("5d063342-47c6-4948-b29b-0487e0884265"), output.Value);			
+		}
+
+		[TestMethod]
+		public void AsThrowsOnInvalidGuids()
+		{
+			string script = @"var output = '5d063342-47c6-4948-b29b-0487e08842'";
+			Context jsContext = new Context();
+			jsContext.Eval(script, true);
+			Assert.ThrowsException<FormatException>(() => jsContext.GetVariable("output").As<Guid>());
+
+			script = @"var output = '5d063342-47c6-4948-b29b-0487e088426j'";
+			Assert.ThrowsException<FormatException>(() => jsContext.GetVariable("output").As<Guid>());
+			
+			script = @"var output = '5d063342-47c6-4948-b29b-0487e08842'";
+			jsContext.Eval(script, true);
+			Assert.ThrowsException<FormatException>(() => jsContext.GetVariable("output").As<Guid?>());
+		}
+	}
+}


### PR DESCRIPTION
I think this should fix a problem I've had (which I reported in #273), with As() not parsing strings from JS into C# Guid's. 