### PR TITLE
Now possible to pass a variables to ExportTable

### DIFF
--- a/NiL.JS/ExportTable.cs
+++ b/NiL.JS/ExportTable.cs
@@ -23,24 +23,44 @@ namespace NiL.JS
 
                 return result;
             }
-            internal set
+             set
             {
                 _items[key] = value;
             }
         }
+        /// <summary>
+        /// Add object constructor to export 
+        /// </summary>
+        /// <remarks>We dont recommend to use, because api can change and its can be broken in future. Use indexers</remarks>
+        /// <param name="type">Class</param>
+        /// <param name="name"></param>
         public void DefineConstructor(Type type, string name)
         {
-            var ctor = GlobalContext.DefaultGlobalContext.GetConstructor(type);
+            var ctor = GlobalContext.CurrentGlobalContext.GetConstructor(type);
             _items.Add(name, ctor);
             ctor._attributes |= JSValueAttributesInternal.DoNotEnumerate;
         }
 
+        /// <summary>
+        /// Add object to exports 
+        /// </summary>
+        /// <remarks>We dont recommend to use, because api can change and its can be broken in future. Use indexers</remarks>
+        /// <param name="name">Name of variable in export</param>
+        /// <param name="deletable"></param>
         public JSValue DefineVariable(string name, bool deletable)
         {
-            var defineVariable = GlobalContext.DefaultGlobalContext.DefineVariable(name, deletable);
+            var defineVariable = GlobalContext.CurrentGlobalContext.DefineVariable(name, deletable);
             _items.Add(name,defineVariable);
             return defineVariable;
         }
+
+        /// <summary>
+        /// Add readonly object to exports 
+        /// </summary>
+        /// <remarks>We dont recommend to use, because api can change and its can be broken in future. Use indexers</remarks>
+        /// <param name="name">Name of variable in export</param>
+        /// <param name="value">JSValue (function, constructor, object, etc)</param>
+        /// <param name="deletable"></param>
         public JSValue DefineConstant(string name, JSValue value, bool deletable = false)
         {
             var v = DefineVariable(name, deletable);

--- a/NiL.JS/ExportTable.cs
+++ b/NiL.JS/ExportTable.cs
@@ -8,6 +8,7 @@ namespace NiL.JS
     public sealed class ExportTable : IEnumerable<KeyValuePair<string, JSValue>>
     {
         private Dictionary<string, JSValue> _items = new Dictionary<string, JSValue>();
+        private readonly Context _context;
 
         public JSValue this[string key]
         {
@@ -28,6 +29,13 @@ namespace NiL.JS
                 _items[key] = value;
             }
         }
+
+
+        public ExportTable(Context moduleContext)
+        {
+            _context = moduleContext;
+        }
+
         /// <summary>
         /// Add object constructor to export 
         /// </summary>
@@ -36,7 +44,7 @@ namespace NiL.JS
         /// <param name="name"></param>
         public void DefineConstructor(Type type, string name)
         {
-            var ctor = GlobalContext.CurrentGlobalContext.GetConstructor(type);
+            var ctor = _context.GlobalContext.GetConstructor(type);
             _items.Add(name, ctor);
             ctor._attributes |= JSValueAttributesInternal.DoNotEnumerate;
         }
@@ -49,7 +57,10 @@ namespace NiL.JS
         /// <param name="deletable"></param>
         public JSValue DefineVariable(string name, bool deletable)
         {
-            var defineVariable = GlobalContext.CurrentGlobalContext.DefineVariable(name, deletable);
+            var defineVariable = new JSValue()
+            {
+                _valueType = JSValueType.Undefined
+            };
             _items.Add(name,defineVariable);
             return defineVariable;
         }

--- a/NiL.JS/ExportTable.cs
+++ b/NiL.JS/ExportTable.cs
@@ -28,7 +28,27 @@ namespace NiL.JS
                 _items[key] = value;
             }
         }
+        public void DefineConstructor(Type type, string name)
+        {
+            var ctor = GlobalContext.DefaultGlobalContext.GetConstructor(type);
+            _items.Add(name, ctor);
+            ctor._attributes |= JSValueAttributesInternal.DoNotEnumerate;
+        }
 
+        public JSValue DefineVariable(string name, bool deletable)
+        {
+            var defineVariable = GlobalContext.DefaultGlobalContext.DefineVariable(name, deletable);
+            _items.Add(name,defineVariable);
+            return defineVariable;
+        }
+        public JSValue DefineConstant(string name, JSValue value, bool deletable = false)
+        {
+            var v = DefineVariable(name, deletable);
+            v.Assign(value);
+            v._attributes |= JSValueAttributesInternal.ReadOnly;
+            return v;
+        }
+        
         public int Count => _items.Count;
 
         public JSValue Default

--- a/NiL.JS/ExportTable.cs
+++ b/NiL.JS/ExportTable.cs
@@ -39,23 +39,20 @@ namespace NiL.JS
         /// <summary>
         /// Add object constructor to export 
         /// </summary>
-        /// <remarks>We dont recommend to use, because api can change and its can be broken in future. Use indexers</remarks>
         /// <param name="type">Class</param>
         /// <param name="name"></param>
-        public void DefineConstructor(Type type, string name)
+        public void AddConstructor(Type type, string name)
         {
             var ctor = _context.GlobalContext.GetConstructor(type);
             _items.Add(name, ctor);
-            ctor._attributes |= JSValueAttributesInternal.DoNotEnumerate;
         }
 
         /// <summary>
         /// Add object to exports 
         /// </summary>
-        /// <remarks>We dont recommend to use, because api can change and its can be broken in future. Use indexers</remarks>
         /// <param name="name">Name of variable in export</param>
         /// <param name="deletable"></param>
-        public JSValue DefineVariable(string name, bool deletable)
+        public JSValue AddVariable(string name, bool deletable)
         {
             var defineVariable = new JSValue()
             {
@@ -68,13 +65,12 @@ namespace NiL.JS
         /// <summary>
         /// Add readonly object to exports 
         /// </summary>
-        /// <remarks>We dont recommend to use, because api can change and its can be broken in future. Use indexers</remarks>
         /// <param name="name">Name of variable in export</param>
         /// <param name="value">JSValue (function, constructor, object, etc)</param>
         /// <param name="deletable"></param>
-        public JSValue DefineConstant(string name, JSValue value, bool deletable = false)
+        public JSValue AddConstant(string name, JSValue value, bool deletable = false)
         {
-            var v = DefineVariable(name, deletable);
+            var v = AddVariable(name, deletable);
             v.Assign(value);
             v._attributes |= JSValueAttributesInternal.ReadOnly;
             return v;

--- a/NiL.JS/Module.cs
+++ b/NiL.JS/Module.cs
@@ -32,7 +32,7 @@ namespace NiL.JS
     {
         private static readonly char[] _pathSplitChars = new[] { '\\', '/' };
 
-        public ExportTable Exports { get; };
+        public ExportTable Exports { get; }
 
         public List<IModuleResolver> ModuleResolversChain { get; } = new List<IModuleResolver>();
 

--- a/NiL.JS/Module.cs
+++ b/NiL.JS/Module.cs
@@ -32,7 +32,7 @@ namespace NiL.JS
     {
         private static readonly char[] _pathSplitChars = new[] { '\\', '/' };
 
-        public ExportTable Exports { get; } = new ExportTable();
+        public ExportTable Exports { get; };
 
         public List<IModuleResolver> ModuleResolversChain { get; } = new List<IModuleResolver>();
 
@@ -161,8 +161,8 @@ namespace NiL.JS
             Context._thisBind = new GlobalObject(Context);
 
             Script = script;
-
             Context._strict = Script.Root._strict;
+            Exports = new ExportTable(Context);
         }
 
         public Module()

--- a/Tests/ModuleTests.cs
+++ b/Tests/ModuleTests.cs
@@ -43,6 +43,7 @@ namespace Tests
         {
             var module = new Module("testclass","");
 
+            
             module.Exports.DefineConstructor(typeof(TestClass), "TestClass");
             var mainModule = new Module("main",@"import {TestClass} from 'testclass'
 

--- a/Tests/ModuleTests.cs
+++ b/Tests/ModuleTests.cs
@@ -44,7 +44,7 @@ namespace Tests
             var module = new Module("testclass","");
 
             
-            module.Exports.DefineConstructor(typeof(TestClass), "TestClass");
+            module.Exports.AddConstructor(typeof(TestClass), "TestClass");
             var mainModule = new Module("main",@"import {TestClass} from 'testclass'
 
 var test = new TestClass('lol')
@@ -74,9 +74,9 @@ var result = test.Get()");
         {
             var module = new Module("testclass","");
 
-            module.Exports.DefineVariable("testFunc", true)
+            module.Exports.AddVariable("testFunc", true)
                 .Assign(GlobalContext.CurrentGlobalContext.ProxyValue(new Func<string>(() => "lol")));
-            module.Exports.DefineConstant("testFuncConst", new Func<string>(() => "const"));
+            module.Exports.AddConstant("testFuncConst", new Func<string>(() => "const"));
 
             var mainModule = new Module("main",@"import {testFunc, testFuncConst} from 'testclass'
 


### PR DESCRIPTION
Hi
For now possible add a variable to export table from c# side
![изображение](https://user-images.githubusercontent.com/58953114/227900996-5371f622-15f5-49a5-a38c-15a8e7d6c9a3.png)

Api is very simillar with JSValue and Context

```csharp
  module.Exports.DefineConstructor(typeof(TestClass), "TestClass");
  
  
   module.Exports.DefineVariable("testFunc", true)
                .Assign(GlobalContext.CurrentGlobalContext.ProxyValue(new Func<string>(() => "lol")));

   module.Exports.DefineConstant("testFuncConst", new Func<string>(() => "const"));
```